### PR TITLE
Handle missing files array during campground update

### DIFF
--- a/controllers/campground.js
+++ b/controllers/campground.js
@@ -67,7 +67,7 @@ module.exports.updateCampground = async (req, res) => {
     const campground = await Campground.findByIdAndUpdate(id, { ...req.body.campground }, { new: true, runValidators: true });
 
     //* we take only the data from the image array and store it in the database ; ...imgs (spread operator)
-    const imgs = req.files.map(file => ({ url: file.path, filename: file.filename, originalname: file.originalname }))
+    const imgs = (req.files || []).map(file => ({ url: file.path, filename: file.filename, originalname: file.originalname }))
     //* we dont want to pass the image array as it is, we want to push the new images to the existing array
     campground.image.push(...imgs);
 


### PR DESCRIPTION
## Summary
- avoid accessing `req.files` when no images are uploaded during a campground update
- ensure updates without new images no longer crash the handler

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbaf8fb7dc832cb282313021b8dcee