### PR TITLE
refactor: use placeholders for client branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,93 +2,93 @@
 
 ![CampVenture Screenshot](screenshots/campVenture.png)
 
-CampVenture is a full-stack web application that allows users to discover, create, and review campgrounds. This project is inspired by Colt Steele's "The Web Developer Bootcamp" course on Udemy that takes me 72 hours in total to complete the entire bootcamp. The estimation time for me to learn and complete this projects is around 3-4 weeks considering the details explanation from Colt Steele that talks deeply about Middleware , the MVC architecture for this project, middleware and the integration of the MapBox into this project websites.
-
-<a href="https://guarded-brook-77953-c2f2c375b2e1.herokuapp.com/" target="_blank">
-    <img src="https://img.shields.io/badge/CampVenture-Visit%20Website-brightgreen?style=for-the-badge&logo=appveyor" alt="CampVenture Website">
-</a>
+CampVenture is a modern single-page application that helps campers discover, create, and review outdoor getaways across Malaysia. The new architecture combines a React front-end (bootstrapped with Vite) with an Express/Node REST API backed by MongoDB, Passport.js authentication, and Mapbox for geospatial visualisations.
 
 ## Tech Stack
 
-- **Frontend:**
-  - HTML
-  - CSS
-  - JavaScript
-  - EJS (Embedded JavaScript templates)
-  - Bootstrap 5 (for responsive design)
+- **Frontend**: React 18, React Router, Axios, Vite, Bootstrap 5, Mapbox GL JS
+- **Backend**: Node.js, Express.js, Passport.js, Mongoose, Joi, Cloudinary SDK
+- **Database**: MongoDB Atlas or self-hosted MongoDB instance
+- **Infrastructure & Tooling**: Helmet, express-session, Swagger UI, Mongo sanitize utilities
 
-- **Backend:**
-  - Node.js
-  - Express.js
+## Getting Started
 
-- **Database:**
-  - MongoDB
-  - Mongoose (ODM for MongoDB)
+1. **Install dependencies**
+   ```bash
+   npm install
+   npm run client:install
+   ```
+2. **Configure environment variables** (create `config/config.env` for the server and `.env` inside `client/`):
+   - **Server** (`config/config.env`)
+     - `NODE_ENV` – `DEVELOPMENT` or `PRODUCTION`
+     - `MONGODB_URL` – MongoDB connection string (used when `NODE_ENV!==DEVELOPMENT`)
+     - `SECRET` – session secret
+     - `MAPBOX_TOKEN` – Mapbox API token for server-side geocoding
+     - `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_KEY`, `CLOUDINARY_SECRET` – Cloudinary credentials
+     - `CLIENT_ORIGIN` – comma-separated list of allowed SPA origins (defaults to `http://localhost:5173`)
+   - **Client** (`client/.env`)
+     - `VITE_MAPBOX_TOKEN` – Mapbox token for the interactive maps in the SPA
+     - `VITE_API_BASE_URL` *(optional)* – override `/api` if the API is hosted on a different origin
+3. **Run the app in development**
+   ```bash
+   # Start the API (port 3000)
+   npm run dev
 
-## Deployment
+   # In another terminal, start the React client (port 5173)
+   npm run client:dev
+   ```
+4. **Build for production**
+   ```bash
+   npm run client:build
+   npm run prod
+   ```
+   The Express server will automatically serve the contents of `client/dist`.
 
-Deployed on [Heroku](https://www.heroku.com/).
+   > **Branding tip:** The React client ships with emoji-based placeholders. Add your own imagery under `client/public/` or
+   > importable assets inside `client/src/` if you want custom logos and backgrounds.
 
-## Security Features
+## Available Scripts
 
-- **Authentication:**
-  - Implemented Passport.js for user authentication
+| Command | Description |
+| --- | --- |
+| `npm run dev` | Start the Express API in development mode with Nodemon. |
+| `npm run prod` | Run the API in production mode (expects built client assets). |
+| `npm run client:dev` | Start the React development server (Vite). |
+| `npm run client:build` | Generate a production build of the React client. |
+| `npm run client:test` | Run the client test suite (Vitest). |
+| `npm run client:install` | Install dependencies for the React client. |
 
-- **Data Validation and Sanitization:**
-  - Used Joi for server-side validation and sanitization
-  - Sanitized HTML inputs to prevent Cross-Site Scripting (XSS) attacks
+## API Overview
 
-- **Mongo Injection Prevention:**
-  - Used Mongoose to prevent NoSQL injection attacks
+The Express application now exposes JSON endpoints under the `/api` prefix:
 
-- **Additional Security Measures:**
-  - Implemented helmet middleware for setting various HTTP headers to secure the application
- 
-<table>
-  <tr>
-    <td>
-      <img src="screenshots/XSS Attack.png" alt="CampVenture Screenshot 1" width="400"/>
-    </td>
-    <td>
-      <img src="screenshots/Error XSS .png" alt="CampVenture Screenshot 2" width="600" height="290"/>
-    </td>
-  </tr>
-</table>
+- `POST /api/auth/register` – create an account and start a session
+- `POST /api/auth/login` / `POST /api/auth/logout`
+- `GET /api/auth/me` – fetch the currently authenticated user
+- `GET /api/campgrounds` – list all campgrounds (with geometry data)
+- `POST /api/campgrounds` – create a campground (multipart form for images)
+- `GET /api/campgrounds/:id` – retrieve a campground with reviews
+- `PUT /api/campgrounds/:id` – update campground details and images
+- `DELETE /api/campgrounds/:id` – remove a campground
+- `POST /api/campgrounds/:id/reviews` & `DELETE /api/campgrounds/:id/reviews/:reviewId`
 
-## Map Integration
-
-- Integrated **Mapbox** for displaying interactive maps and campground locations.
-
-<table>
-  <tr>
-    <td>
-      <img src="screenshots/MapCampVenture.png" alt="CampVenture Screenshot 1" width="550" height="290"/>
-    </td>
-    <td>
-      <img src="screenshots/mapLocation.png" alt="CampVenture Screenshot 2" width="550" height="290"/>
-    </td>
-  </tr>
-</table>
+Swagger documentation remains available at `/api-docs`.
 
 ## Features
 
-- **User Authentication:** Secure login and registration with password hashing.
-- **Campground Management:** CRUD operations for campgrounds.
-- **Reviews:** Users can leave reviews for campgrounds.
-- **Image Uploads:** Users can add multiple images when creating a new campground. Images are stored in Cloudinary.
+- **React SPA** with client-side routing, responsive layouts, and Mapbox-powered visualisations
+- **Secure authentication** via Passport.js sessions with cross-origin support for the SPA
+- **Campground management** including rich image uploads (Cloudinary) and geocoded locations
+- **Reviews system** with rating controls, user ownership checks, and live updates
+- **Security hardening** using Helmet, express-session, input sanitisation, and validation through Joi
 
-<table>
-  <tr>
-    <td>
-      <img src="screenshots/leaveReview.png" alt="CampVenture Screenshot 1" width="550" height="300"/>
-    </td>
-    <td>
-      <img src="screenshots/newCamp.png" alt="CampVenture Screenshot 2" width="550" height="300"/>
-    </td>
-  </tr>
-</table>
+## Deployment Notes
 
+1. Build the React client with `npm run client:build` before deploying the Express server.
+2. Ensure `CLIENT_ORIGIN` and `VITE_MAPBOX_TOKEN` reflect the deployed domains.
+3. When serving behind HTTPS in production, keep `NODE_ENV=PRODUCTION` so cookies are marked `Secure`/`SameSite=None`.
 
 ## Acknowledgements
 
-- Colt Steele's "The Web Developer Bootcamp" course on Udemy for inspiration and guidance.
+- Inspired by Colt Steele's *The Web Developer Bootcamp* curriculum.
+- Map tiles by [Mapbox](https://www.mapbox.com/). Images hosted on [Cloudinary](https://cloudinary.com/).

--- a/app.js
+++ b/app.js
@@ -1,186 +1,200 @@
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
 const mongoose = require('mongoose');
-const methodOverride = require('method-override');
 const morgan = require('morgan');
-const ejsMate = require('ejs-mate');
 const dotenv = require('dotenv');
 dotenv.config({ path: './config/config.env' });
 const ExpressError = require('./utils/ExpressError');
 const session = require('express-session');
-const flash = require('connect-flash');
 const passport = require('passport');
 const LocalStrategy = require('passport-local');
 const User = require('./model/user');
 const mongoSanitize = require('express-mongo-sanitize');
 const helmet = require('helmet');
-const dbUrl = process.env.NODE_ENV === 'DEVELOPMENT'
-    ? 'mongodb://localhost:27017/yelpcamp'
-    : process.env.MONGODB_URL;
 const MongoDBStore = require('connect-mongo');
 const swaggerUI = require('swagger-ui-express');
+const cors = require('cors');
 
 const userRoutes = require('./routes/user');
 const campgroundRoutes = require('./routes/campground');
 const reviewRoutes = require('./routes/review');
-const cors = require('cors');
 
-mongoose.connect(dbUrl,)
-    .then(() => {
-        console.log('Mongo Connection open!')
-    })
-    .catch(err => {
-        console.log('Oh No! Mongo Connection Error')
-        console.log('Error: ', err)
-    })
+const isDevelopment = process.env.NODE_ENV === 'DEVELOPMENT';
+const dbUrl = isDevelopment ? 'mongodb://localhost:27017/yelpcamp' : process.env.MONGODB_URL;
+
+mongoose
+  .connect(dbUrl)
+  .then(() => {
+    console.log('Mongo Connection open!');
+  })
+  .catch((err) => {
+    console.log('Oh No! Mongo Connection Error');
+    console.log('Error: ', err);
+  });
 
 const app = express();
 
-app.engine('ejs', ejsMate);
-app.set('view engine', 'ejs');
-app.set('views', path.join(__dirname, 'views'));
+const allowedOrigins = (process.env.CLIENT_ORIGIN || 'http://localhost:5173')
+  .split(',')
+  .map((origin) => origin.trim());
 
-// Serve the OpenAPI JSON file
 app.use('/openapi.json', express.static(path.join(__dirname, 'openapi.json')));
-
-// Setup Swagger UI to use the served JSON file
-app.use('/api-docs', swaggerUI.serve, swaggerUI.setup(null, {
+app.use(
+  '/api-docs',
+  swaggerUI.serve,
+  swaggerUI.setup(null, {
     swaggerOptions: {
-        url: '/openapi.json' // Path to the JSON file served by your Express app
+      url: '/openapi.json'
     }
-}));
-app.use(cors());
-app.use(express.json()); // For parsing application/json
-app.use(express.urlencoded({ extended: true })); // below is for parsing the form data and adding it to the req.body
-app.use(methodOverride('__method'));
+  })
+);
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error('Not allowed by CORS'));
+    },
+    credentials: true
+  })
+);
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 app.use(morgan('dev'));
 app.use(express.static(path.join(__dirname, 'public')));
+app.use(
+  mongoSanitize({
+    replaceWith: '_'
+  })
+);
+app.use(
+  helmet({
+    crossOriginEmbedderPolicy: false,
+    crossOriginResourcePolicy: false
+  })
+);
+
+const scriptSrcUrls = [
+  'https://stackpath.bootstrapcdn.com',
+  'https://api.tiles.mapbox.com',
+  'https://api.mapbox.com',
+  'https://kit.fontawesome.com',
+  'https://cdnjs.cloudflare.com',
+  'https://cdn.jsdelivr.net'
+];
+const styleSrcUrls = [
+  'https://kit-free.fontawesome.com',
+  'https://stackpath.bootstrapcdn.com',
+  'https://api.mapbox.com',
+  'https://api.tiles.mapbox.com',
+  'https://fonts.googleapis.com',
+  'https://use.fontawesome.com',
+  'https://cdn.jsdelivr.net'
+];
+const connectSrcUrls = [
+  'https://api.mapbox.com',
+  'https://*.tiles.mapbox.com',
+  'https://events.mapbox.com',
+  ...allowedOrigins.filter(Boolean)
+];
+const fontSrcUrls = [
+  'https://fonts.gstatic.com',
+  'https://use.fontawesome.com',
+  'https://cdn.jsdelivr.net'
+];
+
+app.use(
+  helmet.contentSecurityPolicy({
+    directives: {
+      defaultSrc: ["'self'"],
+      connectSrc: ["'self'", ...connectSrcUrls],
+      scriptSrc: ["'self'", "'unsafe-inline'", ...scriptSrcUrls],
+      styleSrc: ["'self'", "'unsafe-inline'", ...styleSrcUrls],
+      workerSrc: ["'self'", 'blob:'],
+      childSrc: ['blob:'],
+      objectSrc: [],
+      imgSrc: [
+        "'self'",
+        'blob:',
+        'data:',
+        'https://res.cloudinary.com/dzosiyaan/',
+        'https://images.unsplash.com'
+      ],
+      fontSrc: ["'self'", ...fontSrcUrls]
+    }
+  })
+);
 
 const secret = process.env.SECRET || 'thisshouldbeabettersecret';
 
-// ? Session Configuration ; must be before the passport configuration
 const store = MongoDBStore.create({
-    mongoUrl: dbUrl,
-    touchAfter: 24 * 60 * 60, // 24 hours ; this is the time in seconds for the session to be updated in 24 hours
-    crypto: {
-        secret
-    }
+  mongoUrl: dbUrl,
+  touchAfter: 24 * 60 * 60,
+  crypto: {
+    secret
+  }
 });
 
-store.on('error', function (e) {
-    console.log('Session Store Error', e);
+store.on('error', (e) => {
+  console.log('Session Store Error', e);
 });
 
-app.use(session({
+app.use(
+  session({
     store,
     name: 'session',
     secret,
     resave: false,
-    saveUninitialized: true,
+    saveUninitialized: false,
     cookie: {
-        expires: Date.now() + 1000 * 60 * 60 * 24 * 7, // 1000ms * 60s * 60m * 24h * 7d = 1 week ; this is the time for the cookie to expire in 1 week
-        maxAge: 1000 * 60 * 60 * 24 * 7,// maxAge is the time in milliseconds for the cookie to expire in 1 week
-        priority: 'high',
-        // //secure: true,
-        httpOnly: true,
+      maxAge: 1000 * 60 * 60 * 24 * 7,
+      httpOnly: true,
+      sameSite: isDevelopment ? 'lax' : 'none',
+      secure: !isDevelopment
     }
-}));
-app.use(flash());
-app.use(mongoSanitize({
-    replaceWith: '_',
-}));
-app.use(helmet());
-
-const scriptSrcUrls = [
-    "https://stackpath.bootstrapcdn.com",
-    "https://api.tiles.mapbox.com",
-    "https://api.mapbox.com",
-    "https://kit.fontawesome.com",
-    "https://cdnjs.cloudflare.com",
-    "https://cdn.jsdelivr.net",
-];
-const styleSrcUrls = [
-    "https://kit-free.fontawesome.com",
-    "https://stackpath.bootstrapcdn.com",
-    "https://api.mapbox.com",
-    "https://api.tiles.mapbox.com",
-    "https://fonts.googleapis.com",
-    "https://use.fontawesome.com",
-    "https://cdn.jsdelivr.net" // CDN for the star rating
-];
-const connectSrcUrls = [
-    "https://api.mapbox.com",
-    "https://*.tiles.mapbox.com",
-    "https://events.mapbox.com",
-];
-const fontSrcUrls = [
-    "https://fonts.gstatic.com", // Google Fonts
-    "https://use.fontawesome.com", // FontAwesome
-    "https://cdn.jsdelivr.net" // CDN for the star rating
-];
-app.use(
-    helmet.contentSecurityPolicy({
-        directives: {
-            defaultSrc: [],
-            connectSrc: ["'self'", ...connectSrcUrls],
-            scriptSrc: ["'unsafe-inline'", "'self'", ...scriptSrcUrls],
-            styleSrc: ["'self'", "'unsafe-inline'", ...styleSrcUrls],
-            workerSrc: ["'self'", "blob:"],
-            childSrc: ["blob:"],
-            objectSrc: [],
-            imgSrc: [
-                "'self'",
-                "blob:",
-                "data:",
-                "https://res.cloudinary.com/dzosiyaan/",
-                "https://images.unsplash.com",
-            ],
-            fontSrc: ["'self'", ...fontSrcUrls],
-        },
-    })
+  })
 );
 
-//? Passport Configuration ; must be after the session configuration ; app.use(session({...}))
 app.use(passport.initialize());
 app.use(passport.session());
 passport.use(new LocalStrategy(User.authenticate()));
-
-//?  how to store and unstore the user in the session
 passport.serializeUser(User.serializeUser());
 passport.deserializeUser(User.deserializeUser());
 
-//? Middleware to show the flash messages in the views template
-app.use((req, res, next) => {
-    console.log(req.query);
-    res.locals.success = req.flash('success');
-    res.locals.error = req.flash('error');
-    res.locals.currentUser = req.user;
-    next();
+app.use('/api/auth', userRoutes);
+app.use('/api/campgrounds', campgroundRoutes);
+app.use('/api/campgrounds/:id/reviews', reviewRoutes);
+
+app.all('/api/*', (req, res, next) => {
+  next(new ExpressError('API route not found', 404));
 });
 
-app.get('/', (req, res) => {
-    res.render('home');
-});
+const clientBuildPath = path.join(__dirname, 'client', 'dist');
+if (fs.existsSync(clientBuildPath)) {
+  app.use(express.static(clientBuildPath));
 
-app.use('/', userRoutes);
-app.use('/campground', campgroundRoutes);
-app.use('/campground/:id/review', reviewRoutes);
+  app.get('*', (req, res, next) => {
+    if (req.path.startsWith('/api') || req.path.startsWith('/openapi') || req.path.startsWith('/api-docs')) {
+      return next();
+    }
+    return res.sendFile(path.join(clientBuildPath, 'index.html'));
+  });
+} else {
+  app.get('/', (req, res) => {
+    res.json({ success: true, message: 'CampVenture API is running' });
+  });
+}
 
-// // app.use((req, res, next) => {
-// // res.status(404).render('404', { err: 'Page not found' });
-
-// ? Error Handling Middleware for non-existing routes 
-app.all('*', (req, res, next) => {
-    next(new ExpressError('Page Not Found', 404));
-})
-
-// ? Error Handling Middleware for async functions 
 app.use((err, req, res, next) => {
-    const { statusCode = 500, message = 'Something went wrong' } = err;
-    res.status(statusCode).render('error', { err });
-})
+  const statusCode = err.statusCode || 500;
+  const message = err.message || 'Something went wrong';
+  res.status(statusCode).json({ success: false, message });
+});
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {
-    console.log(`Serving on port ${port} in ${process.env.NODE_ENV} mode`);
+  console.log(`Serving on port ${port} in ${process.env.NODE_ENV} mode`);
 });

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.dist
+.DS_Store
+.vscode
+.idea
+*.log
+dist

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/camplogo.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CampVenture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "campventure-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint \"src/**/*.{js,jsx}\"",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "axios": "^1.7.9",
+    "clsx": "^2.1.1",
+    "bootstrap": "^5.3.3",
+    "mapbox-gl": "^3.5.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.2",
+    "@vitejs/plugin-react": "^4.3.3",
+    "eslint": "^8.57.1",
+    "eslint-plugin-react": "^7.35.0",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-refresh": "^0.4.10",
+    "vite": "^5.4.10"
+  }
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,35 @@
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import Layout from './components/Layout.jsx';
+import HomePage from './pages/HomePage.jsx';
+import CampgroundsPage from './pages/CampgroundsPage.jsx';
+import CampgroundDetailPage from './pages/CampgroundDetailPage.jsx';
+import NewCampgroundPage from './pages/NewCampgroundPage.jsx';
+import EditCampgroundPage from './pages/EditCampgroundPage.jsx';
+import LoginPage from './pages/LoginPage.jsx';
+import RegisterPage from './pages/RegisterPage.jsx';
+import NotFoundPage from './pages/NotFoundPage.jsx';
+import ProtectedRoute from './components/ProtectedRoute.jsx';
+import { AuthProvider } from './context/AuthContext.jsx';
+
+const App = () => {
+  return (
+    <BrowserRouter>
+      <AuthProvider>
+        <Routes>
+          <Route path="/" element={<Layout />}>
+            <Route index element={<HomePage />} />
+            <Route path="campgrounds" element={<CampgroundsPage />} />
+            <Route path="campgrounds/new" element={<ProtectedRoute><NewCampgroundPage /></ProtectedRoute>} />
+            <Route path="campgrounds/:campgroundId" element={<CampgroundDetailPage />} />
+            <Route path="campgrounds/:campgroundId/edit" element={<ProtectedRoute><EditCampgroundPage /></ProtectedRoute>} />
+            <Route path="login" element={<LoginPage />} />
+            <Route path="register" element={<RegisterPage />} />
+            <Route path="*" element={<NotFoundPage />} />
+          </Route>
+        </Routes>
+      </AuthProvider>
+    </BrowserRouter>
+  );
+};
+
+export default App;

--- a/client/src/components/CampgroundCard.jsx
+++ b/client/src/components/CampgroundCard.jsx
@@ -1,0 +1,29 @@
+import { Link } from 'react-router-dom';
+import { FALLBACK_CAMPGROUND_IMAGE } from '../utils/placeholders.js';
+
+const CampgroundCard = ({ campground }) => {
+  const coverImage = campground?.image?.length ? campground.image[0].url : FALLBACK_CAMPGROUND_IMAGE;
+
+  return (
+    <div className="card h-100 shadow-sm border-0">
+      <img
+        src={coverImage}
+        className="card-img-top"
+        alt={`Image of ${campground.title}`}
+        style={{ height: 220, objectFit: 'cover' }}
+      />
+      <div className="card-body d-flex flex-column">
+        <h5 className="card-title">{campground.title}</h5>
+        <p className="card-text text-muted">{campground.location}</p>
+        <div className="mt-auto d-flex justify-content-between align-items-center">
+          <span className="fw-semibold">RM {campground.price}/night</span>
+          <Link to={`/campgrounds/${campground._id}`} className="btn btn-outline-primary btn-sm">
+            View
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CampgroundCard;

--- a/client/src/components/CampgroundDetailMap.jsx
+++ b/client/src/components/CampgroundDetailMap.jsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react';
+import mapboxgl from 'mapbox-gl';
+import 'mapbox-gl/dist/mapbox-gl.css';
+
+const CampgroundDetailMap = ({ campground }) => {
+  const mapContainer = useRef(null);
+  const mapRef = useRef(null);
+  const token = import.meta.env.VITE_MAPBOX_TOKEN;
+  const coordinates = campground?.geometry?.coordinates;
+
+  useEffect(() => {
+    if (!token || !mapContainer.current || !coordinates || coordinates.length !== 2) {
+      return undefined;
+    }
+
+    mapboxgl.accessToken = token;
+    const map = new mapboxgl.Map({
+      container: mapContainer.current,
+      style: 'mapbox://styles/mapbox/streets-v12',
+      center: coordinates,
+      zoom: 10
+    });
+
+    map.addControl(new mapboxgl.NavigationControl());
+
+    const marker = new mapboxgl.Marker({ color: '#dc3545' })
+      .setLngLat(coordinates)
+      .setPopup(
+        new mapboxgl.Popup({ offset: 24 }).setHTML(
+          `<div style="max-width: 220px;">
+            <h6 style="margin-bottom: 0.5rem;">${campground.title}</h6>
+            <p style="margin: 0; font-size: 0.85rem; color: #64748b;">${campground.location}</p>
+          </div>`
+        )
+      )
+      .addTo(map);
+
+    mapRef.current = map;
+
+    return () => {
+      marker.remove();
+      map.remove();
+      mapRef.current = null;
+    };
+  }, [token, coordinates, campground?.title, campground?.location]);
+
+  if (!token) {
+    return (
+      <div className="alert alert-warning" role="alert">
+        Mapbox token is not configured. Set the <code>VITE_MAPBOX_TOKEN</code> environment variable to enable the map.
+      </div>
+    );
+  }
+
+  if (!coordinates || coordinates.length !== 2) {
+    return <p className="text-muted">Map location will appear once coordinates are available.</p>;
+  }
+
+  return <div ref={mapContainer} style={{ height: 400, borderRadius: '1rem', overflow: 'hidden' }} />;
+};
+
+export default CampgroundDetailMap;

--- a/client/src/components/CampgroundForm.jsx
+++ b/client/src/components/CampgroundForm.jsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+
+const defaultValues = {
+  title: '',
+  price: '',
+  location: '',
+  description: ''
+};
+
+const CampgroundForm = ({
+  initialValues = defaultValues,
+  onSubmit,
+  submitting,
+  submitLabel,
+  heading,
+  existingImages = [],
+  deleteSelection = [],
+  onToggleImage
+}) => {
+  const [values, setValues] = useState({ ...defaultValues, ...initialValues });
+  const [files, setFiles] = useState([]);
+
+  useEffect(() => {
+    setValues({ ...defaultValues, ...initialValues });
+  }, [initialValues]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleFilesChange = (event) => {
+    setFiles(Array.from(event.target.files ?? []));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    await onSubmit({ values, files });
+  };
+
+  return (
+    <form className="card border-0 shadow-sm" onSubmit={handleSubmit}>
+      <div className="card-body p-4">
+        {heading && <h2 className="h4 fw-semibold mb-4 text-center">{heading}</h2>}
+        <div className="mb-3">
+          <label htmlFor="title" className="form-label">
+            Title
+          </label>
+          <input
+            id="title"
+            name="title"
+            className="form-control"
+            placeholder="Campground title"
+            value={values.title}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label htmlFor="price" className="form-label">
+            Price (per night)
+          </label>
+          <div className="input-group">
+            <span className="input-group-text">RM</span>
+            <input
+              id="price"
+              type="number"
+              min="0"
+              name="price"
+              className="form-control"
+              value={values.price}
+              onChange={handleChange}
+              required
+            />
+            <span className="input-group-text">.00</span>
+          </div>
+        </div>
+        <div className="mb-3">
+          <label htmlFor="location" className="form-label">
+            Location
+          </label>
+          <input
+            id="location"
+            name="location"
+            className="form-control"
+            placeholder="City, State"
+            value={values.location}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label htmlFor="description" className="form-label">
+            Description
+          </label>
+          <textarea
+            id="description"
+            name="description"
+            rows={5}
+            className="form-control"
+            placeholder="Describe the campground"
+            value={values.description}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label htmlFor="images" className="form-label">
+            Upload photos
+          </label>
+          <input id="images" type="file" className="form-control" multiple onChange={handleFilesChange} />
+          {files.length > 0 && <small className="text-muted">Selected {files.length} new image(s)</small>}
+        </div>
+        {existingImages.length > 0 && (
+          <div className="mb-3">
+            <p className="fw-semibold">Existing images</p>
+            <div className="row g-3">
+              {existingImages.map((image) => (
+                <div className="col-6 col-md-4" key={image.filename}>
+                  <div className="card h-100 border-0 shadow-sm">
+                    <img src={image.url} className="card-img-top" alt={image.originalname ?? image.filename} style={{ height: 120, objectFit: 'cover' }} />
+                    <div className="card-body py-2">
+                      <div className="form-check">
+                        <input
+                          className="form-check-input"
+                          type="checkbox"
+                          id={`remove-${image.filename}`}
+                          checked={deleteSelection.includes(image.filename)}
+                          onChange={() => onToggleImage?.(image.filename)}
+                        />
+                        <label className="form-check-label" htmlFor={`remove-${image.filename}`}>
+                          Remove
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="card-footer bg-white d-flex justify-content-end gap-3">
+        <button type="submit" className="btn btn-success" disabled={submitting}>
+          {submitting ? 'Saving…' : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default CampgroundForm;

--- a/client/src/components/CampgroundMap.jsx
+++ b/client/src/components/CampgroundMap.jsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from 'react';
+import mapboxgl from 'mapbox-gl';
+import 'mapbox-gl/dist/mapbox-gl.css';
+
+const CampgroundMap = ({ campgrounds }) => {
+  const mapContainer = useRef(null);
+  const mapRef = useRef(null);
+  const token = import.meta.env.VITE_MAPBOX_TOKEN;
+
+  useEffect(() => {
+    if (!token || !mapContainer.current) {
+      return undefined;
+    }
+
+    mapboxgl.accessToken = token;
+
+    const map = new mapboxgl.Map({
+      container: mapContainer.current,
+      style: 'mapbox://styles/mapbox/light-v11',
+      center: [101.9758, 4.2105],
+      zoom: 5
+    });
+
+    map.addControl(new mapboxgl.NavigationControl());
+    mapRef.current = map;
+
+    return () => {
+      map.remove();
+      mapRef.current = null;
+    };
+  }, [token]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) {
+      return;
+    }
+
+    const markers = [];
+
+    campgrounds
+      .filter((campground) => campground.geometry?.coordinates?.length === 2)
+      .forEach((campground) => {
+        const marker = new mapboxgl.Marker({ color: '#198754' })
+          .setLngLat(campground.geometry.coordinates)
+          .setPopup(
+            new mapboxgl.Popup({ offset: 24 }).setHTML(
+              `<div style="max-width: 220px;">
+                <h6 style="margin-bottom: 0.5rem;">${campground.title}</h6>
+                <p style="margin: 0; font-size: 0.85rem; color: #64748b;">${campground.location}</p>
+              </div>`
+            )
+          )
+          .addTo(map);
+
+        markers.push(marker);
+      });
+
+    if (markers.length) {
+      const bounds = new mapboxgl.LngLatBounds();
+      markers.forEach((marker) => bounds.extend(marker.getLngLat()));
+      map.fitBounds(bounds, { padding: 60, maxZoom: 10, duration: 800 });
+    }
+
+    return () => {
+      markers.forEach((marker) => marker.remove());
+    };
+  }, [campgrounds]);
+
+  if (!token) {
+    return (
+      <div className="alert alert-warning" role="alert">
+        Mapbox token is not configured. Set the <code>VITE_MAPBOX_TOKEN</code> environment variable to enable the interactive map.
+      </div>
+    );
+  }
+
+  return <div ref={mapContainer} style={{ height: 400, borderRadius: '1rem', overflow: 'hidden' }} />;
+};
+
+export default CampgroundMap;

--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -1,0 +1,12 @@
+const Footer = () => {
+  return (
+    <footer className="bg-dark text-white py-4 mt-5">
+      <div className="container text-center">
+        <p className="mb-1">&copy; {new Date().getFullYear()} CampVenture. All rights reserved.</p>
+        <small className="text-secondary">Discover and share the best camping spots across Malaysia.</small>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router-dom';
+import Navbar from './Navbar.jsx';
+import Footer from './Footer.jsx';
+
+const Layout = () => {
+  return (
+    <div className="d-flex flex-column min-vh-100 bg-light">
+      <Navbar />
+      <main className="flex-grow-1">
+        <Outlet />
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Layout;

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { Link, NavLink } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+import '../styles/navbar.css';
+
+const BrandMark = () => (
+  <span className="brand-mark" aria-hidden="true">
+    🏕️
+  </span>
+);
+
+const Navbar = () => {
+  const { user, logout } = useAuth();
+  const [expanded, setExpanded] = useState(false);
+
+  const toggleExpanded = () => setExpanded((prev) => !prev);
+  const closeNav = () => setExpanded(false);
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } catch (error) {
+      console.error('Failed to log out', error);
+    } finally {
+      closeNav();
+    }
+  };
+
+  const navLinkClass = ({ isActive }) => `nav-link${isActive ? ' active' : ''}`;
+
+  return (
+    <nav className="navbar navbar-expand-lg navbar-light bg-white shadow-sm py-3 px-3 px-lg-0">
+      <div className="container">
+        <Link className="navbar-brand d-flex align-items-center text-primary fw-semibold" to="/" onClick={closeNav}>
+          <BrandMark />
+          <span className="brand-text">CampVenture</span>
+        </Link>
+        <button
+          className="navbar-toggler mobile-nav-toggle"
+          type="button"
+          aria-controls="primary-navbar"
+          aria-expanded={expanded}
+          aria-label="Toggle navigation"
+          onClick={toggleExpanded}
+        >
+          <span className="navbar-toggler-icon" />
+        </button>
+        <div className={`collapse navbar-collapse${expanded ? ' show' : ''}`} id="primary-navbar">
+          <ul className="navbar-nav mx-auto mb-3 mb-lg-0 gap-lg-3">
+            <li className="nav-item">
+              <NavLink to="/campgrounds" className={navLinkClass} onClick={closeNav}>
+                All Campgrounds
+              </NavLink>
+            </li>
+            {user && (
+              <li className="nav-item">
+                <NavLink to="/campgrounds/new" className={navLinkClass} onClick={closeNav}>
+                  New Campground
+                </NavLink>
+              </li>
+            )}
+          </ul>
+          <div className="navbar-actions ms-lg-3">
+            {user ? (
+              <div className="d-flex flex-column flex-lg-row align-items-lg-center gap-2">
+                <span className="text-muted">
+                  Hi, <strong>{user.username}</strong>
+                </span>
+                <button type="button" className="btn btn-danger" onClick={handleLogout}>
+                  Logout
+                </button>
+              </div>
+            ) : (
+              <div className="d-flex flex-column flex-lg-row align-items-lg-center gap-2">
+                <Link className="btn btn-outline-primary" to="/register" onClick={closeNav}>
+                  Sign up
+                </Link>
+                <Link className="btn btn-primary" to="/login" onClick={closeNav}>
+                  Login
+                </Link>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/client/src/components/ProtectedRoute.jsx
+++ b/client/src/components/ProtectedRoute.jsx
@@ -1,0 +1,24 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+
+const ProtectedRoute = ({ children }) => {
+  const { user, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return (
+      <div className="d-flex justify-content-center align-items-center py-5">
+        <div className="spinner-border text-primary" role="status" aria-hidden="true" />
+        <span className="ms-2">Loading...</span>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;

--- a/client/src/components/ReviewForm.jsx
+++ b/client/src/components/ReviewForm.jsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+const ReviewForm = ({ onSubmit, submitting }) => {
+  const [rating, setRating] = useState(5);
+  const [body, setBody] = useState('');
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    await onSubmit({ rating, body });
+    setBody('');
+    setRating(5);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="card card-body border-0 shadow-sm">
+      <h5 className="card-title">Share your experience</h5>
+      <div className="mb-3">
+        <label htmlFor="rating" className="form-label">
+          Rating
+        </label>
+        <select
+          id="rating"
+          className="form-select"
+          value={rating}
+          onChange={(event) => setRating(Number(event.target.value))}
+          required
+        >
+          {[5, 4, 3, 2, 1].map((value) => (
+            <option key={value} value={value}>
+              {value} star{value === 1 ? '' : 's'}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="mb-3">
+        <label htmlFor="review" className="form-label">
+          Review
+        </label>
+        <textarea
+          id="review"
+          className="form-control"
+          rows={4}
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          required
+        />
+      </div>
+      <button type="submit" className="btn btn-success" disabled={submitting}>
+        {submitting ? 'Submitting…' : 'Post review'}
+      </button>
+    </form>
+  );
+};
+
+export default ReviewForm;

--- a/client/src/components/ReviewList.jsx
+++ b/client/src/components/ReviewList.jsx
@@ -1,0 +1,47 @@
+import clsx from 'clsx';
+
+const renderStars = (rating) => {
+  return Array.from({ length: 5 }).map((_, index) => (
+    <i
+      key={index}
+      className={clsx('bi', index < rating ? 'bi-star-fill text-warning' : 'bi-star text-secondary')}
+      aria-hidden="true"
+    />
+  ));
+};
+
+const ReviewList = ({ reviews, onDelete, currentUserId }) => {
+  if (!reviews?.length) {
+    return <p className="text-muted">No reviews yet. Be the first to share your experience!</p>;
+  }
+
+  return (
+    <div className="list-group list-group-flush">
+      {reviews.map((review) => (
+        <div key={review._id} className="list-group-item py-3">
+          <div className="d-flex justify-content-between align-items-start">
+            <div>
+              <div className="d-flex align-items-center gap-2">
+                <strong>{review.author?.username ?? 'Anonymous camper'}</strong>
+                <div>{renderStars(review.rating)}</div>
+              </div>
+              <p className="mb-1 text-muted small">Reviewed on {new Date(review.createdAt).toLocaleDateString()}</p>
+              <p className="mb-0">{review.body}</p>
+            </div>
+            {currentUserId && review.author?._id === currentUserId && (
+              <button
+                type="button"
+                className="btn btn-sm btn-outline-danger"
+                onClick={() => onDelete(review._id)}
+              >
+                Delete
+              </button>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ReviewList;

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -1,0 +1,54 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import apiClient from '../utils/apiClient';
+
+const AuthContext = createContext({
+  user: null,
+  loading: true,
+  login: async () => {},
+  register: async () => {},
+  logout: async () => {},
+  refreshUser: async () => {}
+});
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const refreshUser = useCallback(async () => {
+    try {
+      const { data } = await apiClient.get('/auth/me');
+      setUser(data?.user ?? null);
+    } catch (error) {
+      setUser(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshUser();
+  }, [refreshUser]);
+
+  const login = useCallback(async (credentials) => {
+    const { data } = await apiClient.post('/auth/login', credentials);
+    setUser(data.user);
+    return data.user;
+  }, []);
+
+  const register = useCallback(async (payload) => {
+    const { data } = await apiClient.post('/auth/register', payload);
+    setUser(data.user);
+    return data.user;
+  }, []);
+
+  const logout = useCallback(async () => {
+    await apiClient.post('/auth/logout');
+    setUser(null);
+  }, []);
+
+  const value = useMemo(() => ({ user, loading, login, register, logout, refreshUser }), [user, loading, login, register, logout, refreshUser]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap-icons/font/bootstrap-icons.css';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/client/src/pages/CampgroundDetailPage.jsx
+++ b/client/src/pages/CampgroundDetailPage.jsx
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import apiClient from '../utils/apiClient';
+import CampgroundDetailMap from '../components/CampgroundDetailMap.jsx';
+import ReviewForm from '../components/ReviewForm.jsx';
+import ReviewList from '../components/ReviewList.jsx';
+import { useAuth } from '../context/AuthContext.jsx';
+import { FALLBACK_CAMPGROUND_IMAGE } from '../utils/placeholders.js';
+
+const CampgroundDetailPage = () => {
+  const { campgroundId } = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [campground, setCampground] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [reviewSubmitting, setReviewSubmitting] = useState(false);
+  const [actionMessage, setActionMessage] = useState(null);
+
+  const isAuthor = useMemo(
+    () => user && campground?.author?._id && user?._id === campground.author._id,
+    [user, campground]
+  );
+
+  const fetchCampground = useCallback(async (showSpinner = true) => {
+    try {
+      if (showSpinner) {
+        setLoading(true);
+      }
+      const { data } = await apiClient.get(`/campgrounds/${campgroundId}`);
+      setCampground(data.campground);
+      setError(null);
+    } catch (err) {
+      setError(err.response?.data?.message || 'Unable to load campground details');
+    } finally {
+      if (showSpinner) {
+        setLoading(false);
+      }
+    }
+  }, [campgroundId]);
+
+  useEffect(() => {
+    fetchCampground();
+  }, [fetchCampground]);
+
+  const handleCampgroundDelete = async () => {
+    if (!window.confirm('Are you sure you want to delete this campground?')) {
+      return;
+    }
+    try {
+      await apiClient.delete(`/campgrounds/${campgroundId}`);
+      navigate('/campgrounds', { replace: true });
+    } catch (err) {
+      setActionMessage(err.response?.data?.message || 'Failed to delete campground');
+    }
+  };
+
+  const handleReviewSubmit = async ({ rating, body }) => {
+    if (!user) {
+      setActionMessage('You need to sign in to leave a review.');
+      return;
+    }
+    try {
+      setReviewSubmitting(true);
+      await apiClient.post(`/campgrounds/${campgroundId}/reviews`, {
+        review: { rating, body }
+      });
+      setActionMessage('Review submitted successfully!');
+      await fetchCampground(false);
+    } catch (err) {
+      setActionMessage(err.response?.data?.message || 'Unable to submit review.');
+    } finally {
+      setReviewSubmitting(false);
+    }
+  };
+
+  const handleReviewDelete = async (reviewId) => {
+    if (!window.confirm('Delete this review?')) {
+      return;
+    }
+    try {
+      await apiClient.delete(`/campgrounds/${campgroundId}/reviews/${reviewId}`);
+      await fetchCampground(false);
+    } catch (err) {
+      setActionMessage(err.response?.data?.message || 'Unable to delete review.');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="d-flex justify-content-center align-items-center py-5">
+        <div className="spinner-border text-primary" role="status" aria-hidden="true" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container py-5">
+        <div className="alert alert-danger" role="alert">
+          {error}
+        </div>
+        <Link to="/campgrounds" className="btn btn-primary">
+          Back to campgrounds
+        </Link>
+      </div>
+    );
+  }
+
+  if (!campground) {
+    return null;
+  }
+
+  const coverImage = campground.image?.length ? campground.image[0].url : FALLBACK_CAMPGROUND_IMAGE;
+
+  return (
+    <div className="container py-4">
+      {actionMessage && (
+        <div className="alert alert-info alert-dismissible fade show" role="alert">
+          {actionMessage}
+          <button type="button" className="btn-close" aria-label="Close" onClick={() => setActionMessage(null)} />
+        </div>
+      )}
+      <div className="row g-4">
+        <div className="col-lg-5">
+          <div className="card border-0 shadow-sm h-100">
+            <img src={coverImage} className="card-img-top" alt={campground.title} />
+            <div className="card-body">
+              <h2 className="h4 fw-bold">{campground.title}</h2>
+              <p className="text-muted mb-2">{campground.location}</p>
+              <p>{campground.description}</p>
+            </div>
+            <div className="card-footer bg-white d-flex justify-content-between align-items-center">
+              <span className="fw-semibold">RM {campground.price} / night</span>
+              <small className="text-muted">Last updated {new Date(campground.updatedAt).toLocaleString()}</small>
+            </div>
+          </div>
+        </div>
+        <div className="col-lg-7">
+          <CampgroundDetailMap campground={campground} />
+          {isAuthor && (
+            <div className="d-flex gap-3 mt-4">
+              <Link to={`/campgrounds/${campground._id}/edit`} className="btn btn-outline-primary flex-grow-1">
+                Edit Campground
+              </Link>
+              <button type="button" className="btn btn-outline-danger flex-grow-1" onClick={handleCampgroundDelete}>
+                Delete Campground
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <section className="mt-5">
+        <div className="row g-4">
+          <div className="col-lg-6">
+            <h3 className="h5 mb-3">Reviews</h3>
+            <ReviewList
+              reviews={campground.reviews}
+              currentUserId={user?._id}
+              onDelete={handleReviewDelete}
+            />
+          </div>
+          <div className="col-lg-6">
+            {user ? (
+              <ReviewForm onSubmit={handleReviewSubmit} submitting={reviewSubmitting} />
+            ) : (
+              <div className="card card-body border-0 shadow-sm">
+                <h5 className="card-title">Sign in to review</h5>
+                <p className="mb-0 text-muted">
+                  <Link to="/login">Log in</Link> or <Link to="/register">create an account</Link> to share your experience.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default CampgroundDetailPage;

--- a/client/src/pages/CampgroundsPage.jsx
+++ b/client/src/pages/CampgroundsPage.jsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import apiClient from '../utils/apiClient';
+import CampgroundCard from '../components/CampgroundCard.jsx';
+import CampgroundMap from '../components/CampgroundMap.jsx';
+
+const CampgroundsPage = () => {
+  const [campgrounds, setCampgrounds] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchCampgrounds = async () => {
+      try {
+        const { data } = await apiClient.get('/campgrounds');
+        setCampgrounds(data.campgrounds ?? []);
+      } catch (err) {
+        setError(err.response?.data?.message || 'Unable to load campgrounds');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCampgrounds();
+  }, []);
+
+  return (
+    <div className="container py-4">
+      <header className="text-center mb-4">
+        <h1 className="fw-bold">Explore Campgrounds in Malaysia</h1>
+        <p className="text-muted">Discover detailed information, plan your next adventure, and contribute your own camping experiences.</p>
+      </header>
+
+      <div className="mb-5">
+        <CampgroundMap campgrounds={campgrounds} />
+      </div>
+
+      {loading && (
+        <div className="d-flex justify-content-center py-5">
+          <div className="spinner-border text-primary" role="status" aria-hidden="true" />
+        </div>
+      )}
+
+      {error && (
+        <div className="alert alert-danger" role="alert">
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && campgrounds.length === 0 && (
+        <p className="text-center text-muted">No campgrounds available yet. Be the first to add one!</p>
+      )}
+
+      {!loading && !error && campgrounds.length > 0 && (
+        <div className="row g-4">
+          {campgrounds.map((campground) => (
+            <div className="col-md-6 col-lg-4" key={campground._id}>
+              <CampgroundCard campground={campground} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CampgroundsPage;

--- a/client/src/pages/EditCampgroundPage.jsx
+++ b/client/src/pages/EditCampgroundPage.jsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import CampgroundForm from '../components/CampgroundForm.jsx';
+import apiClient from '../utils/apiClient';
+
+const EditCampgroundPage = () => {
+  const { campgroundId } = useParams();
+  const navigate = useNavigate();
+  const [campground, setCampground] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+  const [deleteSelection, setDeleteSelection] = useState([]);
+
+  useEffect(() => {
+    const fetchCampground = async () => {
+      try {
+        const { data } = await apiClient.get(`/campgrounds/${campgroundId}`);
+        setCampground(data.campground);
+        setError(null);
+      } catch (err) {
+        setError(err.response?.data?.message || 'Unable to load campground');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCampground();
+  }, [campgroundId]);
+
+  const handleSubmit = async ({ values, files }) => {
+    const formData = new FormData();
+    Object.entries(values).forEach(([key, value]) => {
+      formData.append(`campground[${key}]`, value);
+    });
+    files.forEach((file) => formData.append('image', file));
+    deleteSelection.forEach((filename) => formData.append('deleteImages', filename));
+
+    try {
+      setSubmitting(true);
+      setError(null);
+      const { data } = await apiClient.put(`/campgrounds/${campgroundId}`, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+      });
+      navigate(`/campgrounds/${data.campground._id}`);
+    } catch (err) {
+      setError(err.response?.data?.message || 'Unable to update campground');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const toggleDeleteSelection = (filename) => {
+    setDeleteSelection((current) =>
+      current.includes(filename) ? current.filter((item) => item !== filename) : [...current, filename]
+    );
+  };
+
+  if (loading) {
+    return (
+      <div className="d-flex justify-content-center align-items-center py-5">
+        <div className="spinner-border text-primary" role="status" aria-hidden="true" />
+      </div>
+    );
+  }
+
+  if (!campground) {
+    return (
+      <div className="container py-4">
+        <div className="alert alert-danger" role="alert">
+          {error || 'Campground not found'}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container py-4">
+      <div className="row justify-content-center">
+        <div className="col-lg-8">
+          {error && (
+            <div className="alert alert-danger" role="alert">
+              {error}
+            </div>
+          )}
+          <CampgroundForm
+            heading={`Edit ${campground.title}`}
+            submitLabel="Save changes"
+            onSubmit={handleSubmit}
+            submitting={submitting}
+            initialValues={{
+              title: campground.title,
+              price: campground.price,
+              location: campground.location,
+              description: campground.description
+            }}
+            existingImages={campground.image}
+            deleteSelection={deleteSelection}
+            onToggleImage={toggleDeleteSelection}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EditCampgroundPage;

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom';
+import '../styles/home.css';
+
+const HomePage = () => {
+  return (
+    <section className="home-hero">
+      <div className="home-hero-content">
+        <h1>CampVenture</h1>
+        <p>
+          Welcome to CampVenture! Discover Malaysia&apos;s most breathtaking camping spots, share your own hidden gems, and
+          connect with fellow outdoor enthusiasts.
+        </p>
+        <Link className="btn btn-lg btn-secondary home-cta" to="/campgrounds">
+          Explore Campgrounds
+        </Link>
+        <footer className="home-footer">
+          <p className="mb-0">&copy; {new Date().getFullYear()} CampVenture</p>
+        </footer>
+      </div>
+    </section>
+  );
+};
+
+export default HomePage;

--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+import '../styles/auth.css';
+
+const LoginPage = () => {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [formValues, setFormValues] = useState({ username: '', password: '' });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    try {
+      setSubmitting(true);
+      setError(null);
+      await login(formValues);
+      const redirectTo = location.state?.from?.pathname ?? '/campgrounds';
+      navigate(redirectTo, { replace: true });
+    } catch (err) {
+      setError(err.response?.data?.message || 'Invalid username or password');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="auth-wrapper">
+      <div className="container">
+        <div className="row justify-content-center">
+          <div className="col-lg-10 col-xl-9">
+            <div className="row g-0 auth-card">
+              <div className="col-lg-5 d-flex flex-column align-items-center justify-content-center text-center auth-illustration p-4">
+                <div className="auth-illustration-icon" aria-hidden="true">🧭</div>
+                <h2 className="fw-semibold">Welcome back</h2>
+                <p className="mb-0">Sign in to continue exploring and sharing breathtaking campgrounds.</p>
+              </div>
+              <div className="col-lg-7 bg-white">
+                <div className="auth-form">
+                  <h1 className="h3 fw-bold mb-3 text-center">Login to CampVenture</h1>
+                  <p className="text-muted text-center mb-4">We&apos;re excited to see you again.</p>
+
+                  {error && (
+                    <div className="alert alert-danger" role="alert">
+                      {error}
+                    </div>
+                  )}
+
+                  <form onSubmit={handleSubmit}>
+                    <div className="mb-3">
+                      <label htmlFor="username" className="form-label">
+                        Username
+                      </label>
+                      <input
+                        id="username"
+                        name="username"
+                        className="form-control form-control-lg"
+                        placeholder="Your username"
+                        value={formValues.username}
+                        onChange={handleChange}
+                        required
+                      />
+                    </div>
+                    <div className="mb-4">
+                      <label htmlFor="password" className="form-label">
+                        Password
+                      </label>
+                      <input
+                        id="password"
+                        type="password"
+                        name="password"
+                        className="form-control form-control-lg"
+                        placeholder="Your password"
+                        value={formValues.password}
+                        onChange={handleChange}
+                        required
+                      />
+                    </div>
+                    <button type="submit" className="btn btn-primary w-100 btn-lg" disabled={submitting}>
+                      {submitting ? 'Signing in…' : 'Login'}
+                    </button>
+                  </form>
+
+                  <p className="text-center text-muted mt-4 mb-0">
+                    Don&apos;t have an account? <Link to="/register">Sign up</Link>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/client/src/pages/NewCampgroundPage.jsx
+++ b/client/src/pages/NewCampgroundPage.jsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import CampgroundForm from '../components/CampgroundForm.jsx';
+import apiClient from '../utils/apiClient';
+
+const NewCampgroundPage = () => {
+  const navigate = useNavigate();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async ({ values, files }) => {
+    const formData = new FormData();
+    Object.entries(values).forEach(([key, value]) => {
+      formData.append(`campground[${key}]`, value);
+    });
+    files.forEach((file) => formData.append('image', file));
+
+    try {
+      setSubmitting(true);
+      setError(null);
+      const { data } = await apiClient.post('/campgrounds', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+      });
+      navigate(`/campgrounds/${data.campground._id}`);
+    } catch (err) {
+      setError(err.response?.data?.message || 'Unable to create campground');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="container py-4">
+      <div className="row justify-content-center">
+        <div className="col-lg-8">
+          {error && (
+            <div className="alert alert-danger" role="alert">
+              {error}
+            </div>
+          )}
+          <CampgroundForm
+            heading="New Campground"
+            submitLabel="Create Campground"
+            onSubmit={handleSubmit}
+            submitting={submitting}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NewCampgroundPage;

--- a/client/src/pages/NotFoundPage.jsx
+++ b/client/src/pages/NotFoundPage.jsx
@@ -1,0 +1,15 @@
+import { Link } from 'react-router-dom';
+
+const NotFoundPage = () => {
+  return (
+    <div className="container py-5 text-center">
+      <h1 className="display-4 fw-bold mb-3">Page not found</h1>
+      <p className="lead text-muted mb-4">The page you are looking for might have been removed or temporarily unavailable.</p>
+      <Link to="/" className="btn btn-primary">
+        Back to Home
+      </Link>
+    </div>
+  );
+};
+
+export default NotFoundPage;

--- a/client/src/pages/RegisterPage.jsx
+++ b/client/src/pages/RegisterPage.jsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+import '../styles/auth.css';
+
+const RegisterPage = () => {
+  const { register } = useAuth();
+  const navigate = useNavigate();
+  const [formValues, setFormValues] = useState({ username: '', email: '', password: '' });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    try {
+      setSubmitting(true);
+      setError(null);
+      await register(formValues);
+      navigate('/campgrounds', { replace: true });
+    } catch (err) {
+      setError(err.response?.data?.message || 'Unable to create account');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="auth-wrapper">
+      <div className="container">
+        <div className="row justify-content-center">
+          <div className="col-lg-10 col-xl-9">
+            <div className="row g-0 auth-card">
+              <div className="col-lg-5 d-flex flex-column align-items-center justify-content-center text-center auth-illustration p-4">
+                <div className="auth-illustration-icon" aria-hidden="true">🌄</div>
+                <h2 className="fw-semibold">Join the community</h2>
+                <p className="mb-0">Create an account to share your adventures and discover new destinations.</p>
+              </div>
+              <div className="col-lg-7 bg-white">
+                <div className="auth-form">
+                  <h1 className="h3 fw-bold mb-3 text-center">Create your account</h1>
+                  <p className="text-muted text-center mb-4">Start your next camping adventure with CampVenture.</p>
+
+                  {error && (
+                    <div className="alert alert-danger" role="alert">
+                      {error}
+                    </div>
+                  )}
+
+                  <form onSubmit={handleSubmit}>
+                    <div className="mb-3">
+                      <label htmlFor="register-username" className="form-label">
+                        Username
+                      </label>
+                      <input
+                        id="register-username"
+                        name="username"
+                        className="form-control form-control-lg"
+                        placeholder="Choose a username"
+                        value={formValues.username}
+                        onChange={handleChange}
+                        required
+                      />
+                    </div>
+                    <div className="mb-3">
+                      <label htmlFor="register-email" className="form-label">
+                        Email
+                      </label>
+                      <input
+                        id="register-email"
+                        type="email"
+                        name="email"
+                        className="form-control form-control-lg"
+                        placeholder="you@example.com"
+                        value={formValues.email}
+                        onChange={handleChange}
+                        required
+                      />
+                    </div>
+                    <div className="mb-4">
+                      <label htmlFor="register-password" className="form-label">
+                        Password
+                      </label>
+                      <input
+                        id="register-password"
+                        type="password"
+                        name="password"
+                        className="form-control form-control-lg"
+                        placeholder="Create a strong password"
+                        value={formValues.password}
+                        onChange={handleChange}
+                        required
+                      />
+                    </div>
+                    <button type="submit" className="btn btn-success w-100 btn-lg" disabled={submitting}>
+                      {submitting ? 'Creating account…' : 'Sign up'}
+                    </button>
+                  </form>
+
+                  <p className="text-center text-muted mt-4 mb-0">
+                    Already have an account? <Link to="/login">Sign in</Link>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RegisterPage;

--- a/client/src/styles/auth.css
+++ b/client/src/styles/auth.css
@@ -1,0 +1,42 @@
+.auth-wrapper {
+  min-height: calc(100vh - 200px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1rem;
+}
+
+.auth-card {
+  border: none;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  box-shadow: 0 1rem 2.5rem rgba(15, 23, 42, 0.12);
+}
+
+.auth-illustration {
+  background: linear-gradient(135deg, rgba(1, 32, 78, 0.9), rgba(0, 153, 112, 0.8));
+  color: #fff;
+}
+
+.auth-illustration-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 120px;
+  height: 120px;
+  margin-bottom: 1.5rem;
+  font-size: 3rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+}
+
+.auth-form {
+  padding: 3rem 2.5rem;
+}
+
+@media (max-width: 991.98px) {
+  .auth-form {
+    padding: 2rem 1.5rem;
+  }
+}

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -1,0 +1,29 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #1f2933;
+  background-color: #f8f9fa;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #f8f9fa;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}

--- a/client/src/styles/home.css
+++ b/client/src/styles/home.css
@@ -1,0 +1,48 @@
+.home-hero {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 160px);
+  padding: 4rem 1rem;
+  color: #fff;
+  text-align: center;
+  background-image: radial-gradient(circle at top left, rgba(34, 197, 94, 0.25), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.25), transparent 45%),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.88), rgba(2, 132, 199, 0.82));
+  background-size: cover;
+  background-position: center;
+}
+
+.home-hero-content {
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.home-hero h1 {
+  font-size: clamp(2.75rem, 6vw, 4rem);
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+.home-hero p {
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
+  margin-bottom: 0;
+}
+
+.home-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.9rem 2.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.home-footer {
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.9rem;
+}

--- a/client/src/styles/navbar.css
+++ b/client/src/styles/navbar.css
@@ -1,0 +1,50 @@
+.navbar-brand {
+  gap: 0.75rem;
+}
+
+.brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  font-size: 1.5rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #0f172a, #2563eb);
+  color: #fff;
+}
+
+.brand-text {
+  letter-spacing: 0.05em;
+}
+
+.navbar-nav .nav-link {
+  font-weight: 500;
+  color: #475569;
+}
+
+.navbar-nav .nav-link.active {
+  color: #0f172a;
+}
+
+.navbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.navbar-actions .btn {
+  border-radius: 999px;
+  padding-inline: 1.25rem;
+}
+
+.mobile-nav-toggle {
+  border: none;
+  background: transparent;
+}
+
+@media (max-width: 991.98px) {
+  .navbar-actions {
+    margin-top: 1rem;
+  }
+}

--- a/client/src/styles/register.css
+++ b/client/src/styles/register.css
@@ -1,0 +1,380 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
+
+body {
+    font-family: 'Poppins', sans-serif;
+    line-height: 1.6;
+    color: #333;
+    background-color: #F0EBE3;
+    height: 130vh;
+}
+
+main {
+    margin-top: 9px;
+}
+
+.card {
+    border-radius: 10px;
+    box-shadow: 5px 5px 10px 1px rgba(0, 0, 0, 0.2);
+    border: none;
+}
+
+#card_show {
+    border-radius: 0 0 10px 10px;
+}
+
+#image_thumbnail {
+    width: 100%;
+    height: 700px;
+    object-fit: cover;
+    border-radius: 10px 0 0 10px;
+    box-shadow: 5px 5px 10px 1px rgba(0, 0, 0, 0.2);
+}
+
+@media screen and (max-width: 992px) {
+    #image_thumbnail {
+        width: 100%;
+        height: 400px;
+        object-fit: cover;
+        border-radius: 10px 10px 0 0;
+        box-shadow: 5px 5px 10px 1px rgba(0, 0, 0, 0.2);
+    }
+
+}
+
+.box-area {
+    width: 1040px;
+    position: relative;
+    top: 50px;
+}
+
+#map {
+    /* position: static;  */
+    /* top: 168px; 
+    bottom: 10;  */
+    margin: 10px 0 40px 0;
+    width: 100%;
+    height: 400px;
+    border-radius: 25px;
+    box-shadow: 5px 5px 10px 1px rgba(0, 0, 0, 0.2);
+}
+
+#myTabContent {
+    height: 100%;
+}
+
+.tab-pane {
+    height: 100%;
+}
+
+#mapShow {
+    height: 100%;
+    width: 100%;
+    border-radius: 20px;
+    box-shadow: 5px 5px 10px 1px rgba(0, 0, 0, 0.2);
+}
+
+#menu {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    padding: 10px;
+    font-family: "Poppins", sans-serif;
+    z-index: 1;
+}
+
+.right-box {
+    padding: 40px 30px 40px 40px;
+}
+
+.edit-left-box {
+    padding: 10px 40px 40px 40px;
+}
+
+.new-box {
+    background-color: white;
+    padding: 40px 30px 40px 40px;
+    box-shadow: 5px 5px 10px 1px rgba(0, 0, 0, 0.2);
+}
+
+.vh-75 {
+    height: 75vh;
+}
+
+.nav-link {
+    font-size: 20px;
+}
+
+.wrapper {
+    background: #ececec;
+    padding: 0 20px 0 20px;
+}
+
+#alert {
+    position: absolute;
+    top: 15px;
+    left: 505px;
+}
+
+.mainRegister {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    margin-top: -10px;
+}
+
+.rowRegister {
+    width: 900px;
+    height: 550px;
+    border-radius: 10px;
+    background: #fff;
+    box-shadow: 5px 5px 10px 1px rgba(0, 0, 0, 0.2);
+}
+
+div.side-image {
+    background-image: url('https://images.unsplash.com/photo-1682686581220-689c34afb6ef?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D');
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
+    position: relative;
+    border-radius: 10px 0 0 10px;
+}
+
+div.input-box img {
+    width: 50px;
+    /* height: auto !important; */
+    position: absolute;
+    top: 45px;
+    left: 44%;
+}
+
+#username {
+    margin-top: 60px;
+
+}
+
+div.side-image div.text {
+    position: absolute;
+    top: 77%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+}
+
+div.side-image div.text p {
+    font-size: 22px;
+    /* font-weight: 500; */
+    color: #fff;
+}
+
+.right {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+}
+
+.input-box {
+    width: 330px;
+    box-sizing: border-box;
+}
+
+.input-box header {
+    font-weight: 700;
+    text-align: center;
+    /* margin-bottom: 45px; */
+    position: absolute;
+    top: 110px;
+    left: 0;
+    right: 0;
+    text-align: center;
+}
+
+.input-field {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    padding: 0 10px 0 10px;
+}
+
+.input {
+    height: 45px;
+    width: 100%;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+    outline: none;
+    margin-bottom: 20px;
+    color: #40414a;
+}
+
+.input-box .input-field label {
+    position: absolute;
+    top: 10px;
+    pointer-events: none;
+    left: 10px;
+    transition: .5s;
+}
+
+.input-field .input:focus~label {
+    top: -10px;
+    font-size: 13px;
+}
+
+.input-field input:valid~label {
+    top: -10px;
+    font-size: 13px;
+    color: #5d5076;
+}
+
+.input-field .input:focus,
+.input-field .input:valid {
+    border-bottom: 1px solid #743ae1;
+}
+
+.submit {
+    border: none;
+    outline: none;
+    height: 45px;
+    background: #ececec;
+    border-radius: 5px;
+    transition: .4s;
+}
+
+.submit:hover {
+    background: rgba(37, 95, 156, 0.937);
+    color: #fff;
+}
+
+.signin {
+    text-align: center;
+    font-size: small;
+    margin-top: 25px;
+}
+
+span a {
+    text-decoration: none;
+    font-weight: 700;
+    color: #000;
+    transition: .5s;
+}
+
+span a:hover {
+    text-decoration: underline;
+    color: #000;
+}
+
+object[data="/stylesheets/pictures/camp3.svg"] {
+    width: 500px;
+    /* adjust as needed */
+    height: 650px;
+    /* adjust as needed */
+}
+
+object[data="/stylesheets/pictures/campfest.svg"] {
+    width: 250px;
+    /* adjust as needed */
+    height: 125px;
+    /* margin-top: 5px;  */
+    margin-left: 10px;
+}
+
+.img-fluid {
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
+    max-height: 600px;
+    overflow: hidden;
+    border-radius: 10px 0 0 10px;
+}
+
+figure {
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
+    max-height: 320px;
+    /* overflow: hidden; */
+    margin: 10px 0;
+}
+
+@media (min-width: 1300px) {
+    .container {
+        max-width: 90%;
+    }
+}
+
+@media only screen and (max-width: 768px) {
+    body {
+        height: 110vh;
+    }
+
+    .box-area {
+        /* margin: 100px 10px; */
+        position: relative;
+        top: 55px;
+    }
+
+    .left-box {
+        height: 100px;
+        overflow: hidden;
+    }
+
+    .right-box {
+        padding: 20px;
+    }
+
+    div.side-image {
+        border-radius: 10px 10px 0 0;
+        height: 125px;
+        margin: 0;
+        background-position: top;
+    }
+
+    div.right {
+        height: 380px;
+    }
+
+    div.input-box img {
+        width: 35px;
+        position: absolute;
+        top: 1px;
+        left: 45%;
+        /* margin-top: 5px; */
+    }
+
+    div.input-box header {
+        font-weight: 700;
+        text-align: center;
+        position: absolute;
+        top: 45px;
+        left: 0;
+        right: 0;
+    }
+
+    div.side-image div.text {
+        position: absolute;
+        top: 70%;
+        text-align: center;
+        margin-bottom: 30px;
+    }
+
+    div.side-image div.text p {
+        font-size: 16px;
+        margin-bottom: 40px;
+    }
+
+    #username {
+        margin-top: 100px;
+    }
+
+    .rowRegister {
+        max-width: 420px;
+        width: 100%;
+        height: 570px;
+        max-height: 600px;
+    }
+
+    .img-fluid {
+        border-radius: 10px 10px 0 0;
+    }
+}

--- a/client/src/styles/stars.css
+++ b/client/src/styles/stars.css
@@ -1,0 +1,302 @@
+.starability-result {
+    position: relative;
+    width: 150px;
+    height: 30px;
+    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAA8CAMAAABGivqtAAAAxlBMVEUAAACZmZn2viTHuJ72viOampqampr1viSampr3vySampqdnZ34wiX1vSSampr1vSOZmZmampr1viT2vSOampr2viT2viSampr2viSampr2vyX4vyWbm5v3vSSdnZ32wSadnZ36wCWcnJyZmZn/wSr/2ySampr2vSP2viSZmZn2vSSZmZn2vST2viSampr2viSbm5ubm5uZmZn1vSSampqbm5v2vSWampqampr3vSf5wiT5vyagoKD/xCmkpKT/yCSZmZn1vSO4V2dEAAAAQHRSTlMA+vsG9fO6uqdgRSIi7+3q39XVqZWVgnJyX09HPDw1NTAwKRkYB+jh3L6+srKijY2Ef2lpYllZUU5CKigWFQ4Oneh1twAAAZlJREFUOMuV0mdzAiEQBmDgWq4YTWIvKRqT2Htv8P//VJCTGfYQZnw/3fJ4tyO76KE0m1b2fZu+U/pu4QGlA7N+Up5PIz9d+cmkbSrSNr9seT3GKeNYIyeO5j16S28exY5suK0U/QKmmeCCX6xs22hJLVkitMImxCvEs8EG3SCRCN/ViFPqnq5epIzZ07QJJvkM9Tkz1xnkmXbfSvR7f4H8AtXBkLGj74mMvjM1+VHZpAZ4LM4K/LBWEI9jwP71v1ZEQ6dyvQMf8A/1pmdZnKce/VH1iIsdte4U8VEtY23xOujxtFpWDgKbfjD2YeEhY0OzfjGeLyO/XfnNpAcmcjDwKOXRfU1IyiTRyEkaiz67pb9oJHJb9vVqKfgjLBPyF5Sq9T0KmSUhQmtiQrJGPHVi0DoSabj31G2gW3buHd0pY85lNdcCk8xlNDPXMuSyNiwl+theIb9C7RLIpKvviYy+M6H8qGwSAp6Is19+GP6KxwnggJ/kq6Jht5rnRQA4z9zyRRaXssvyqp5I6Vutv0vkpJaJtnjpz/8B19ytIayazLoAAAAASUVORK5CYII=");
+    font-size: 0.1em;
+    color: transparent;
+}
+
+.starability-result:after {
+    content: ' ';
+    position: absolute;
+    left: 0;
+    height: 30px;
+    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAA8CAMAAABGivqtAAAAxlBMVEUAAACZmZn2viTHuJ72viOampqampr1viSampr3vySampqdnZ34wiX1vSSampr1vSOZmZmampr1viT2vSOampr2viT2viSampr2viSampr2vyX4vyWbm5v3vSSdnZ32wSadnZ36wCWcnJyZmZn/wSr/2ySampr2vSP2viSZmZn2vSSZmZn2vST2viSampr2viSbm5ubm5uZmZn1vSSampqbm5v2vSWampqampr3vSf5wiT5vyagoKD/xCmkpKT/yCSZmZn1vSO4V2dEAAAAQHRSTlMA+vsG9fO6uqdgRSIi7+3q39XVqZWVgnJyX09HPDw1NTAwKRkYB+jh3L6+srKijY2Ef2lpYllZUU5CKigWFQ4Oneh1twAAAZlJREFUOMuV0mdzAiEQBmDgWq4YTWIvKRqT2Htv8P//VJCTGfYQZnw/3fJ4tyO76KE0m1b2fZu+U/pu4QGlA7N+Up5PIz9d+cmkbSrSNr9seT3GKeNYIyeO5j16S28exY5suK0U/QKmmeCCX6xs22hJLVkitMImxCvEs8EG3SCRCN/ViFPqnq5epIzZ07QJJvkM9Tkz1xnkmXbfSvR7f4H8AtXBkLGj74mMvjM1+VHZpAZ4LM4K/LBWEI9jwP71v1ZEQ6dyvQMf8A/1pmdZnKce/VH1iIsdte4U8VEtY23xOujxtFpWDgKbfjD2YeEhY0OzfjGeLyO/XfnNpAcmcjDwKOXRfU1IyiTRyEkaiz67pb9oJHJb9vVqKfgjLBPyF5Sq9T0KmSUhQmtiQrJGPHVi0DoSabj31G2gW3buHd0pY85lNdcCk8xlNDPXMuSyNiwl+theIb9C7RLIpKvviYy+M6H8qGwSAp6Is19+GP6KxwnggJ/kq6Jht5rnRQA4z9zyRRaXssvyqp5I6Vutv0vkpJaJtnjpz/8B19ytIayazLoAAAAASUVORK5CYII=");
+    background-position: 0 -30px;
+}
+
+.starability-result[data-rating="5"]::after {
+    width: 150px;
+}
+
+.starability-result[data-rating="4"]::after {
+    width: 120px;
+}
+
+.starability-result[data-rating="3"]::after {
+    width: 90px;
+}
+
+.starability-result[data-rating="2"]::after {
+    width: 60px;
+}
+
+.starability-result[data-rating="1"]::after {
+    width: 30px;
+}
+
+@media screen and (-webkit-min-device-pixel-ratio: 2),
+screen and (min-resolution: 192dpi) {
+    .starability-result {
+        background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAB4CAMAAACZ62E6AAABAlBMVEUAAACZmZmampr2vSObm5v/yiufn5+ampr1viP1viSZmZn2viOZmZmampqampr2viSampqampqcnJz5vyScnJz3wSf/wyn/xiujo6Oqqqr/0C/1vSOampr2viP2viOampr2viP2vST2viOampqampqampr1vyP3viSampr2vyT4vyX3viSbm5ubm5v5wCT8xSmgoKCampqampr3vyb2wiWenp72viOampqZmZmampr2viP2viP1viSampqbm5v2vyT3viObm5v4vyadnZ34wSSbm5v2viSZmZn2viP2vST2viP2viT1viOZmZn2viT2viX3viT3vyb2vyOZmZn1vSOZmZlNN+fKAAAAVHRSTlMA9uz4PQwS8O7r5+fTw4yMelw2MB0dFRELBgbS+/Hfu7uxqKWdg4N7ZmZMPi8pKRgPs0w7Nhb14drKw6Gck21tXkNDIyMZ1rDLycTBtaqVknlfV0sGP8ZwAAADW0lEQVRYw9zWvYqDQBSG4TPDoCAqKhYKQgoVLFaIgZCkiCBBUqVazv3fyu4aEXWdM85Uy779A+LP58AfTQgw73AwtxFiZIwbxMbUfuB3H4b49YNfZrbGodoI52+cm9hH9sbZwwAXOFbo2zjDsSzWxnecuuvaM8MpdtbEPs7y9azF5phZWrjERaWOPdpLbB81cICrgv3W4mvMLbU6RmFQeA5u5HhFEEbHLdWLsMxvHJXxW16Goh+ZqPyny1Az5j79SsCJoWHsBNAxQ9sNF26bWFuMC8v1LY+mmeTadjaqtaNnnXoxWBcde1nNWnzdb68xrOqvu22/MTzuPutujpJ122NvluSb8tTWk85CclDZQwLS0oa2TQpEKacsJy0kSJaQOKJxROKKxhWJ7zS+k9ijsUdim8Y2ZWNUFBP4pMKfOv8onX9WrsI5gd3VVLXtatxcuU0znGUHCUAS2DgrS6mT6hTzrXEjfIZj5Dk2xKkihqm4wKlQfQRqalhUP9UHo3FIPAG/Et44JVLsDDf0JHmB3OEByOwZES8hSAsviGjBdh3ylh6plmMnW4IyAUVJWcE/76vTell1EIaiMBwIAcWBA9GC0lIdKFXQQUsHVVCklN7ojf3+z3JOxYqK2TH555+K6CJJQtRbr9XtDmCnjH0AX9Va8J+liIMvDtRsCk2pEs6hKVexR2g7KuDihwt5a9MfprY0fkLXU9ZmFLpoJolN6GXKWWfZx0tHCocwKJSxC22ItYUEjmBUJHFjfYz1xQxlfaLiZsBExq2IPtbkNbLtOwwuGgjTLkH43mYtSzam7+1Bsr3nm5uExBQUozEh9V7N7uvmwZcqdpm0C6vJW63bZEuXtbrV2zpDzhrpYLBWMnY1mjV7JWFtMio7zbWniWFxvHnWm1yGxXmOPXP+L3YV2ysjnNhaZNeMcHPvuL27BMnVMaujljBAYyje4niH4g2ONyh+4PiB4gOODyjWcKxh1gZBNoJjEY4R/BLhF4IDEQ4QPBoEoyxH4+bxrUsHyxwxQlg0WHXqYifVLmo67cKY/UtaXFxBV26TLjuHrkp8BPJTMij1xQejdkgO24nf7dBOCRcbzQuNOR9Qs64GzzrfQa8It2oFAA6Zrga9xEeq1KHmLUHIiCAWInsg1x/MLqkMsItF8QAAAABJRU5ErkJggg==");
+        background-size: 30px auto;
+    }
+
+    .starability-result:after {
+        background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAB4CAMAAACZ62E6AAABAlBMVEUAAACZmZmampr2vSObm5v/yiufn5+ampr1viP1viSZmZn2viOZmZmampqampr2viSampqampqcnJz5vyScnJz3wSf/wyn/xiujo6Oqqqr/0C/1vSOampr2viP2viOampr2viP2vST2viOampqampqampr1vyP3viSampr2vyT4vyX3viSbm5ubm5v5wCT8xSmgoKCampqampr3vyb2wiWenp72viOampqZmZmampr2viP2viP1viSampqbm5v2vyT3viObm5v4vyadnZ34wSSbm5v2viSZmZn2viP2vST2viP2viT1viOZmZn2viT2viX3viT3vyb2vyOZmZn1vSOZmZlNN+fKAAAAVHRSTlMA9uz4PQwS8O7r5+fTw4yMelw2MB0dFRELBgbS+/Hfu7uxqKWdg4N7ZmZMPi8pKRgPs0w7Nhb14drKw6Gck21tXkNDIyMZ1rDLycTBtaqVknlfV0sGP8ZwAAADW0lEQVRYw9zWvYqDQBSG4TPDoCAqKhYKQgoVLFaIgZCkiCBBUqVazv3fyu4aEXWdM85Uy779A+LP58AfTQgw73AwtxFiZIwbxMbUfuB3H4b49YNfZrbGodoI52+cm9hH9sbZwwAXOFbo2zjDsSzWxnecuuvaM8MpdtbEPs7y9azF5phZWrjERaWOPdpLbB81cICrgv3W4mvMLbU6RmFQeA5u5HhFEEbHLdWLsMxvHJXxW16Goh+ZqPyny1Az5j79SsCJoWHsBNAxQ9sNF26bWFuMC8v1LY+mmeTadjaqtaNnnXoxWBcde1nNWnzdb68xrOqvu22/MTzuPutujpJ122NvluSb8tTWk85CclDZQwLS0oa2TQpEKacsJy0kSJaQOKJxROKKxhWJ7zS+k9ijsUdim8Y2ZWNUFBP4pMKfOv8onX9WrsI5gd3VVLXtatxcuU0znGUHCUAS2DgrS6mT6hTzrXEjfIZj5Dk2xKkihqm4wKlQfQRqalhUP9UHo3FIPAG/Et44JVLsDDf0JHmB3OEByOwZES8hSAsviGjBdh3ylh6plmMnW4IyAUVJWcE/76vTell1EIaiMBwIAcWBA9GC0lIdKFXQQUsHVVCklN7ojf3+z3JOxYqK2TH555+K6CJJQtRbr9XtDmCnjH0AX9Va8J+liIMvDtRsCk2pEs6hKVexR2g7KuDihwt5a9MfprY0fkLXU9ZmFLpoJolN6GXKWWfZx0tHCocwKJSxC22ItYUEjmBUJHFjfYz1xQxlfaLiZsBExq2IPtbkNbLtOwwuGgjTLkH43mYtSzam7+1Bsr3nm5uExBQUozEh9V7N7uvmwZcqdpm0C6vJW63bZEuXtbrV2zpDzhrpYLBWMnY1mjV7JWFtMio7zbWniWFxvHnWm1yGxXmOPXP+L3YV2ysjnNhaZNeMcHPvuL27BMnVMaujljBAYyje4niH4g2ONyh+4PiB4gOODyjWcKxh1gZBNoJjEY4R/BLhF4IDEQ4QPBoEoyxH4+bxrUsHyxwxQlg0WHXqYifVLmo67cKY/UtaXFxBV26TLjuHrkp8BPJTMij1xQejdkgO24nf7dBOCRcbzQuNOR9Qs64GzzrfQa8It2oFAA6Zrga9xEeq1KHmLUHIiCAWInsg1x/MLqkMsItF8QAAAABJRU5ErkJggg==");
+        background-size: 30px auto;
+    }
+}
+
+@-webkit-keyframes heartbeat {
+    0% {
+        -webkit-transform: translateY(15px);
+        transform: translateY(15px);
+    }
+
+    30% {
+        -webkit-transform: translateY(0);
+        transform: translateY(0);
+        opacity: 1;
+    }
+
+    45% {
+        -webkit-transform: translateY(0);
+        transform: translateY(0);
+        -webkit-transform: scale(0.8, 0.8);
+        transform: scale(0.8, 0.8);
+    }
+
+    50% {
+        -webkit-transform: scale(0.7, 0.7);
+        transform: scale(0.7, 0.7);
+    }
+
+    75% {
+        opacity: 0.9;
+    }
+
+    100% {
+        -webkit-transform: scale(1.25, 1.25);
+        transform: scale(1.25, 1.25);
+        opacity: 0;
+    }
+}
+
+@keyframes heartbeat {
+    0% {
+        -webkit-transform: translateY(15px);
+        transform: translateY(15px);
+    }
+
+    30% {
+        -webkit-transform: translateY(0);
+        transform: translateY(0);
+        opacity: 1;
+    }
+
+    45% {
+        -webkit-transform: translateY(0);
+        transform: translateY(0);
+        -webkit-transform: scale(0.8, 0.8);
+        transform: scale(0.8, 0.8);
+    }
+
+    50% {
+        -webkit-transform: scale(0.7, 0.7);
+        transform: scale(0.7, 0.7);
+    }
+
+    75% {
+        opacity: 0.9;
+    }
+
+    100% {
+        -webkit-transform: scale(1.25, 1.25);
+        transform: scale(1.25, 1.25);
+        opacity: 0;
+    }
+}
+
+.starability-heartbeat {
+    display: block;
+    position: relative;
+    width: 150px;
+    min-height: 60px;
+    padding: 0;
+    border: none;
+    will-change: contents;
+}
+
+.starability-heartbeat>input {
+    position: absolute;
+    margin-right: -100%;
+    opacity: 0;
+}
+
+.starability-heartbeat>input:checked~label,
+.starability-heartbeat>input:focus~label {
+    background-position: 0 0;
+}
+
+.starability-heartbeat>input:checked+label,
+.starability-heartbeat>input:focus+label {
+    background-position: 0 -30px;
+}
+
+.starability-heartbeat>input[disabled]:hover+label {
+    cursor: default;
+}
+
+.starability-heartbeat>input:not([disabled]):hover~label {
+    background-position: 0 0;
+}
+
+.starability-heartbeat>input:not([disabled]):hover+label {
+    background-position: 0 -30px;
+}
+
+.starability-heartbeat>input:not([disabled]):hover+label::before {
+    opacity: 1;
+}
+
+.starability-heartbeat>input:focus+label {
+    outline: 1px dotted #999;
+}
+
+.starability-heartbeat .starability-focus-ring {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 30px;
+    outline: 2px dotted #999;
+    pointer-events: none;
+    opacity: 0;
+}
+
+.starability-heartbeat>.input-no-rate:focus~.starability-focus-ring {
+    opacity: 1;
+}
+
+.starability-heartbeat>label {
+    position: relative;
+    display: inline-block;
+    float: left;
+    width: 30px;
+    height: 30px;
+    font-size: 0.1em;
+    color: transparent;
+    cursor: pointer;
+    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAA8CAMAAABGivqtAAAAxlBMVEUAAACZmZn2viTHuJ72viOampqampr1viSampr3vySampqdnZ34wiX1vSSampr1vSOZmZmampr1viT2vSOampr2viT2viSampr2viSampr2vyX4vyWbm5v3vSSdnZ32wSadnZ36wCWcnJyZmZn/wSr/2ySampr2vSP2viSZmZn2vSSZmZn2vST2viSampr2viSbm5ubm5uZmZn1vSSampqbm5v2vSWampqampr3vSf5wiT5vyagoKD/xCmkpKT/yCSZmZn1vSO4V2dEAAAAQHRSTlMA+vsG9fO6uqdgRSIi7+3q39XVqZWVgnJyX09HPDw1NTAwKRkYB+jh3L6+srKijY2Ef2lpYllZUU5CKigWFQ4Oneh1twAAAZlJREFUOMuV0mdzAiEQBmDgWq4YTWIvKRqT2Htv8P//VJCTGfYQZnw/3fJ4tyO76KE0m1b2fZu+U/pu4QGlA7N+Up5PIz9d+cmkbSrSNr9seT3GKeNYIyeO5j16S28exY5suK0U/QKmmeCCX6xs22hJLVkitMImxCvEs8EG3SCRCN/ViFPqnq5epIzZ07QJJvkM9Tkz1xnkmXbfSvR7f4H8AtXBkLGj74mMvjM1+VHZpAZ4LM4K/LBWEI9jwP71v1ZEQ6dyvQMf8A/1pmdZnKce/VH1iIsdte4U8VEtY23xOujxtFpWDgKbfjD2YeEhY0OzfjGeLyO/XfnNpAcmcjDwKOXRfU1IyiTRyEkaiz67pb9oJHJb9vVqKfgjLBPyF5Sq9T0KmSUhQmtiQrJGPHVi0DoSabj31G2gW3buHd0pY85lNdcCk8xlNDPXMuSyNiwl+theIb9C7RLIpKvviYy+M6H8qGwSAp6Is19+GP6KxwnggJ/kq6Jht5rnRQA4z9zyRRaXssvyqp5I6Vutv0vkpJaJtnjpz/8B19ytIayazLoAAAAASUVORK5CYII=");
+    background-repeat: no-repeat;
+    background-position: 0 -30px;
+}
+
+.starability-heartbeat>label::before {
+    content: '';
+    position: absolute;
+    display: block;
+    height: 30px;
+    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAA8CAMAAABGivqtAAAAxlBMVEUAAACZmZn2viTHuJ72viOampqampr1viSampr3vySampqdnZ34wiX1vSSampr1vSOZmZmampr1viT2vSOampr2viT2viSampr2viSampr2vyX4vyWbm5v3vSSdnZ32wSadnZ36wCWcnJyZmZn/wSr/2ySampr2vSP2viSZmZn2vSSZmZn2vST2viSampr2viSbm5ubm5uZmZn1vSSampqbm5v2vSWampqampr3vSf5wiT5vyagoKD/xCmkpKT/yCSZmZn1vSO4V2dEAAAAQHRSTlMA+vsG9fO6uqdgRSIi7+3q39XVqZWVgnJyX09HPDw1NTAwKRkYB+jh3L6+srKijY2Ef2lpYllZUU5CKigWFQ4Oneh1twAAAZlJREFUOMuV0mdzAiEQBmDgWq4YTWIvKRqT2Htv8P//VJCTGfYQZnw/3fJ4tyO76KE0m1b2fZu+U/pu4QGlA7N+Up5PIz9d+cmkbSrSNr9seT3GKeNYIyeO5j16S28exY5suK0U/QKmmeCCX6xs22hJLVkitMImxCvEs8EG3SCRCN/ViFPqnq5epIzZ07QJJvkM9Tkz1xnkmXbfSvR7f4H8AtXBkLGj74mMvjM1+VHZpAZ4LM4K/LBWEI9jwP71v1ZEQ6dyvQMf8A/1pmdZnKce/VH1iIsdte4U8VEtY23xOujxtFpWDgKbfjD2YeEhY0OzfjGeLyO/XfnNpAcmcjDwKOXRfU1IyiTRyEkaiz67pb9oJHJb9vVqKfgjLBPyF5Sq9T0KmSUhQmtiQrJGPHVi0DoSabj31G2gW3buHd0pY85lNdcCk8xlNDPXMuSyNiwl+theIb9C7RLIpKvviYy+M6H8qGwSAp6Is19+GP6KxwnggJ/kq6Jht5rnRQA4z9zyRRaXssvyqp5I6Vutv0vkpJaJtnjpz/8B19ytIayazLoAAAAASUVORK5CYII=");
+    background-position: 0 30px;
+    pointer-events: none;
+    opacity: 0;
+}
+
+.starability-heartbeat>label:nth-of-type(5)::before {
+    width: 120px;
+    left: -120px;
+}
+
+.starability-heartbeat>label:nth-of-type(4)::before {
+    width: 90px;
+    left: -90px;
+}
+
+.starability-heartbeat>label:nth-of-type(3)::before {
+    width: 60px;
+    left: -60px;
+}
+
+.starability-heartbeat>label:nth-of-type(2)::before {
+    width: 30px;
+    left: -30px;
+}
+
+.starability-heartbeat>label:nth-of-type(1)::before {
+    width: 0px;
+    left: 0px;
+}
+
+@media screen and (-webkit-min-device-pixel-ratio: 2),
+screen and (min-resolution: 192dpi) {
+    .starability-heartbeat>label {
+        background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAB4CAMAAACZ62E6AAABAlBMVEUAAACZmZmampr2vSObm5v/yiufn5+ampr1viP1viSZmZn2viOZmZmampqampr2viSampqampqcnJz5vyScnJz3wSf/wyn/xiujo6Oqqqr/0C/1vSOampr2viP2viOampr2viP2vST2viOampqampqampr1vyP3viSampr2vyT4vyX3viSbm5ubm5v5wCT8xSmgoKCampqampr3vyb2wiWenp72viOampqZmZmampr2viP2viP1viSampqbm5v2vyT3viObm5v4vyadnZ34wSSbm5v2viSZmZn2viP2vST2viP2viT1viOZmZn2viT2viX3viT3vyb2vyOZmZn1vSOZmZlNN+fKAAAAVHRSTlMA9uz4PQwS8O7r5+fTw4yMelw2MB0dFRELBgbS+/Hfu7uxqKWdg4N7ZmZMPi8pKRgPs0w7Nhb14drKw6Gck21tXkNDIyMZ1rDLycTBtaqVknlfV0sGP8ZwAAADW0lEQVRYw9zWvYqDQBSG4TPDoCAqKhYKQgoVLFaIgZCkiCBBUqVazv3fyu4aEXWdM85Uy779A+LP58AfTQgw73AwtxFiZIwbxMbUfuB3H4b49YNfZrbGodoI52+cm9hH9sbZwwAXOFbo2zjDsSzWxnecuuvaM8MpdtbEPs7y9azF5phZWrjERaWOPdpLbB81cICrgv3W4mvMLbU6RmFQeA5u5HhFEEbHLdWLsMxvHJXxW16Goh+ZqPyny1Az5j79SsCJoWHsBNAxQ9sNF26bWFuMC8v1LY+mmeTadjaqtaNnnXoxWBcde1nNWnzdb68xrOqvu22/MTzuPutujpJ122NvluSb8tTWk85CclDZQwLS0oa2TQpEKacsJy0kSJaQOKJxROKKxhWJ7zS+k9ijsUdim8Y2ZWNUFBP4pMKfOv8onX9WrsI5gd3VVLXtatxcuU0znGUHCUAS2DgrS6mT6hTzrXEjfIZj5Dk2xKkihqm4wKlQfQRqalhUP9UHo3FIPAG/Et44JVLsDDf0JHmB3OEByOwZES8hSAsviGjBdh3ylh6plmMnW4IyAUVJWcE/76vTell1EIaiMBwIAcWBA9GC0lIdKFXQQUsHVVCklN7ojf3+z3JOxYqK2TH555+K6CJJQtRbr9XtDmCnjH0AX9Va8J+liIMvDtRsCk2pEs6hKVexR2g7KuDihwt5a9MfprY0fkLXU9ZmFLpoJolN6GXKWWfZx0tHCocwKJSxC22ItYUEjmBUJHFjfYz1xQxlfaLiZsBExq2IPtbkNbLtOwwuGgjTLkH43mYtSzam7+1Bsr3nm5uExBQUozEh9V7N7uvmwZcqdpm0C6vJW63bZEuXtbrV2zpDzhrpYLBWMnY1mjV7JWFtMio7zbWniWFxvHnWm1yGxXmOPXP+L3YV2ysjnNhaZNeMcHPvuL27BMnVMaujljBAYyje4niH4g2ONyh+4PiB4gOODyjWcKxh1gZBNoJjEY4R/BLhF4IDEQ4QPBoEoyxH4+bxrUsHyxwxQlg0WHXqYifVLmo67cKY/UtaXFxBV26TLjuHrkp8BPJTMij1xQejdkgO24nf7dBOCRcbzQuNOR9Qs64GzzrfQa8It2oFAA6Zrga9xEeq1KHmLUHIiCAWInsg1x/MLqkMsItF8QAAAABJRU5ErkJggg==");
+        background-size: 30px auto;
+    }
+}
+
+@media screen and (-ms-high-contrast: active) {
+    .starability-heartbeat {
+        width: auto;
+    }
+
+    .starability-heartbeat>input {
+        position: static;
+        margin-right: 0;
+        opacity: 1;
+    }
+
+    .starability-heartbeat .input-no-rate {
+        display: none;
+    }
+
+    .starability-heartbeat>label {
+        display: inline;
+        float: none;
+        width: auto;
+        height: auto;
+        font-size: 1em;
+        color: inherit;
+        background: none;
+    }
+
+    .starability-heartbeat>label::before,
+    .starability-heartbeat>label::after {
+        display: none;
+    }
+}
+
+.starability-heartbeat>label::after {
+    content: ' ';
+    position: absolute;
+    opacity: 0;
+    width: 30px;
+    height: 30px;
+    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAcCAYAAAB2+A+pAAAAAXNSR0IArs4c6QAAAsJJREFUSA29lt9LFFEUx8+5u+5CLUEstlRsO5tKPvXjRXoSQpDUfiAhQS9FEIo+CP0Dbe+9FBIZEfgSRL2k4RbUq0S+SBBRGeOmmUJF6Ja67s7pnLE7O667Nis5A8M598z3nM+cuXdmLkLJMVfXuWepsHwBAc4TwF4k2AlAPxHxBREMG5l0uiTFHk4d7Oggq3Ca9S0c2A0Ii0Awi6ge1oQCD/Z9GPnmzuP6xSNjtPcTWTcYGCxG13sI+DgQiXTH3z76IVdmGjuj+aXlQQI6t17pGiGs8o1fNcz0gI7aYOrqCmTGs3eJ6LK+sJnlIu8SQTgmmkyeJvhJNG6md64hDBqXjvdiKmXZYO602yLrjiPw4qC6bsvIuuZFrjWo1BXDHL2H3+vbdi3kYRKIavVFTxYxZ+uIQp70WoQ4HwnXNAQX8tgHZFUHlSLVAjWYKJZdyfUpBKtVx/yyPL+tipf8Ib+ADocXoyLEqBPwyRGm4hf+l088B4NEWcWrZNaJ+Od8ZTCO+cfTJBxTEMDneuibZaZKKHrKn8A5v6DCEqbCyfQKAd7yCywsYfIcA0TCwQH+68xsN1wYwhKODa59P7yICnq3HcwMYTlgcRJmegQQh7YNzrVtxl+A3XERFuvhyX9VHP8fb61mrMddzf4fuwPzyTOx37T6mv8+B9zxLfuIn3dgTVPMHJ531yjpGEAEKqRO8GPPuIVb8rmG1CqFSq0NHWvAl7qz8Vwh95I7b9Cxqizix1Ag1LL/05PpcnkbOtaitQRs5s7HdcyztXOwuRJU6lTsWEOovi2cycPtKjaC93kj2CsfCV2jnP0nWCeZRjuvSrpZcctj78GwPzk16mnT6BksNzCdPHm4QDjE3R/VNySWX5eJANLFuPnsjTu+mV9xjsslSeFENN7EG7UUT9KqnOJLrBpoudqeYzPJU0fk9JxQIvwDg4rmetWjBsMAAAAASUVORK5CYII=");
+    background-repeat: no-repeat;
+    bottom: 30px;
+    left: 0;
+    z-index: 2;
+}
+
+@media screen and (-webkit-min-device-pixel-ratio: 2),
+screen and (min-resolution: 192dpi) {
+    .starability-heartbeat>label::after {
+        background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA4CAYAAAChbZtkAAAAAXNSR0IArs4c6QAABddJREFUaAXtmm1sFEUYx+fZu4NS2gDie0pvryDFD6gJMegXbf0gfREMJASjCTFIQKEi0QTUD1q/+IKJRi1GjfhCjGJIgNj0rgoR0EQNSQ2JUQgpvb0rxhqwgLZY6d2O/2ftlOv1Xna9vZO7c5LLvD3zzP+3Mzt7uzMkbAbZ3q717/xukSmpSUhxO35+IWStEKQhHkF8VpD4gYQ8Kr2+Tr2383ubrlOaReuabo2bdA9830ySFsJoFtJTJFGcpIgib+D3LX4hvxE8SoRSG4Gy2ZyuX1Y9PDK6DnabpZA12exVPQQcE1J2+AO3vUOH2mOqPFMsF63zRQf7HzalaEPb+ZlsE+uIhIH+XvFd4d1xfU/nhcS65HRG4LDe8iBG7FUp5czkhnbzDO4R4pE5RuhwpjbG3Oa7ZFy+iZlTn8kuUx0JOoMZsClgBD9JZ5cSOLKwdZb5R/wDdL4sXUMn5egkRqS1Yeq9naqd4W/agFvidcwgXJvcA0Z8d7WX1s7uDf2e7G0S8KkFy2fHRkYOYFRvSTbONU+atkUPB19O9BPWm57EhX0hscyVNIkjQlQsCRj7ziX6mwA8WLdyxnlz6GvcP7xIuB4w5UzSqMkfDu5n59FA892mKUIYWSx87gf011NZVdVw9Y+7h5T3CcCGv/kjdP6AqsxLTHR6+vSqOvY9PDzUh4t7VV76GXOKNeR93QitUX2MA0f15lVxKXepinzGGtFW+CdTyhfz2Y/yDcgVeqR7L+ctYH4cRM709zl57Chn/yrGKFvt8jy649qIIrq+eB4/Hq17Jzp46r6CwbIKBi0U7D/9+Q3jyEpOWsBYkR/nTCkHkvIJ5qOf594752Lsr2gpwyo271RvjRYzRxtUQanH5misUcN0bix1UMUnTa1Bw7+cG1RB6ceyXhMkryx90DFCsGKEqXyAwapJkjPKZYSZFc9hGiwXYGYFsBwoH2A5wP+0yghYMDBFymeEKcJT+mC5AOP70Zear2Lafv4SUerQzKhVVBzQao7v/U2S6Cl1YGZkVl608GdLdJc6sGK0gDWf+BCfPmx9uS/GC8NszMjaLeDa3tBJDPkXxQhjRzOzMeM4MCfIQ9vsNC5GG5Kel5RujPalENabD+Nb0x2XSkogRfRVwAjdqUisKa0y5NGeKqV7mVmYSfFxPAFYP9n1DTajdiYaFHOaWZgpkWECMFdUkm8rHtJnE42KMc0MzJKsfRLwNeHPfsV7I3bzijswA7MkU0wCZoOA0b0LezIF2XZJFuRGnrUzQypfKYHZsNor1guiE6kaXdZl0GxpTyMyLTBvJmtesRwr3fhWYxofl00xa2XNqTbClci0wGzg7w39hGh1MbxNjWlcPaZZ8U2KMwKzNW8z4pzO5kktL7MC1qi2RDNJywrMjf3h0BuYLhOOKmRyWug61sYa7fQLW/sBh0868Eq10X6L/FsCYDtGts1uT7ZGWDnzG6FHsXv/lsr/1zFrYU1OdDgCxvNN1oaDG7BA2Jo+ToQ4tWUNlhabJ/CUf0fA3Iih9UhoE07jPKOcFDrmvi0NDmEt/bmIjegt67Hduh3HJVw5UJZNC0Y1jgu+Md0Bt2ztcwZmB1G9dUlcxD/FB6L87lGROO8RnlW1RtfndsDS2ThapdM5CetLF5Ac7cQKPi+dTS7lENkrybc0YHQez8UPt3V8D6fqkIV4qqoX44yj618/2Sf7dgOWtbsywuoi4H7GgaiWp5F/Ltf7mu9X+HkW9+vzvFCqPnKNXQVWYgx/ayM+9H+MC3CtKnMSA3AAH1bv1yNdB520s2PrypRO7oiFTvWKmyB8X3Jdtjy34bb5gOW+8zLCiVA4sLoG39Jew5ysSixPTkMIXkPpMTxf30uuczOfd2AWG5nfWicvxndIKRpSicfCdIimeB7yn+jqS1XvZllBgFkwL2jRupa1gN6G9Ewuw/Q9B9gttX3Bd5F2bWFi3+lCwYCVAOPGFdeJPy90WPlplW36sT2/qLr/4zxcgb8BJJ/aG25iv4UAAAAASUVORK5CYII=");
+        background-size: 30px auto;
+    }
+}
+
+.starability-heartbeat>input:checked+label::after {
+    opacity: 1;
+    -webkit-animation-name: heartbeat;
+    animation-name: heartbeat;
+    -webkit-animation-timing-function: cubic-bezier(0.19, 1, 0.69, 1.35);
+    animation-timing-function: cubic-bezier(0.19, 1, 0.69, 1.35);
+    -webkit-animation-duration: 1s;
+    animation-duration: 1s;
+    -webkit-animation-fill-mode: forwards;
+    animation-fill-mode: forwards;
+}

--- a/client/src/utils/apiClient.js
+++ b/client/src/utils/apiClient.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
+  withCredentials: true
+});
+
+export default apiClient;

--- a/client/src/utils/placeholders.js
+++ b/client/src/utils/placeholders.js
@@ -1,0 +1,2 @@
+export const FALLBACK_CAMPGROUND_IMAGE =
+  'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80';

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        secure: false
+      }
+    }
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true
+  }
+});

--- a/controllers/campground.js
+++ b/controllers/campground.js
@@ -4,101 +4,173 @@ const mbxGeocoding = require('@mapbox/mapbox-sdk/services/geocoding');
 const mapBoxToken = process.env.MAPBOX_TOKEN;
 const geocoder = mbxGeocoding({ accessToken: mapBoxToken });
 
-module.exports.index = async (req, res) => {
-    const campgrounds = await Campground.find({});
-    if (req.accepts('html')) {
-        res.render('campground/index', { campgrounds });
-    } else {
-        res.status(200).json({ campgrounds });
-    }
+const mapUser = (user) => {
+  if (!user) {
+    return null;
+  }
+  const plain = user.toObject ? user.toObject() : user;
+  const id = plain._id || plain;
+  return {
+    _id: id,
+    username: plain.username,
+    email: plain.email
+  };
 };
 
-module.exports.renderNewCampgroundForm = (req, res) => {
-    res.render('campground/new')
+const mapReview = (review) => {
+  if (!review) {
+    return null;
+  }
+  const plain = review.toObject ? review.toObject({ virtuals: true }) : review;
+  return {
+    _id: plain._id,
+    body: plain.body,
+    rating: plain.rating,
+    createdAt: plain.createdAt,
+    updatedAt: plain.updatedAt,
+    author: mapUser(plain.author)
+  };
+};
+
+const formatCampground = (campground) => {
+  if (!campground) {
+    return campground;
+  }
+  const doc = campground.toObject({ virtuals: true });
+  return {
+    _id: doc._id,
+    title: doc.title,
+    description: doc.description,
+    location: doc.location,
+    price: doc.price,
+    geometry: doc.geometry,
+    createdAt: doc.createdAt,
+    updatedAt: doc.updatedAt,
+    properties: doc.properties,
+    image: (doc.image || []).map((image) => ({
+      url: image.url,
+      filename: image.filename,
+      originalname: image.originalname
+    })),
+    author: mapUser(doc.author),
+    reviews: Array.isArray(doc.reviews) ? doc.reviews.map(mapReview).filter(Boolean) : []
+  };
+};
+
+module.exports.index = async (req, res) => {
+  const campgrounds = await Campground.find({}).populate('author');
+  res.status(200).json({ success: true, campgrounds: campgrounds.map(formatCampground) });
 };
 
 module.exports.newCampground = async (req, res) => {
-    try {
-        const geoData = await geocoder.forwardGeocode({
-            query: req.body.campground.location,
-            limit: 1
-        }).send()
+  const geoData = await geocoder
+    .forwardGeocode({
+      query: req.body.campground.location,
+      limit: 1
+    })
+    .send();
 
-        const newCampground = new Campground(req.body.campground);
-        // below line is to store the image in the database in the form of an array
-        newCampground.image = (req.files || []).map(file => ({
-            url: file.path,
-            filename: file.filename,
-            originalname: file.originalname
-        }));
-        newCampground.author = req.user._id;
-        newCampground.geometry = geoData.body.features[0].geometry;
-        await newCampground.save();
+  const newCampground = new Campground(req.body.campground);
+  newCampground.image = (req.files || []).map((file) => ({
+    url: file.path,
+    filename: file.filename,
+    originalname: file.originalname
+  }));
+  newCampground.author = req.user._id;
+  if (geoData?.body?.features?.[0]?.geometry) {
+    newCampground.geometry = geoData.body.features[0].geometry;
+  }
 
-        req.flash('success', 'Successfully made a new campground!')
+  await newCampground.save();
+  await newCampground.populate(['author', { path: 'reviews', populate: 'author' }]);
 
-        req.accepts('html')
-            ? res.redirect(`/campground/${newCampground._id}`)
-            : res.status(200).json({ newCampground });
-    } catch (error) {
-        req.accepts('html')
-            ? res.redirect('/campground/new')
-            : res.status(400).json({ error: error.message });
-    }
+  res.status(201).json({ success: true, campground: formatCampground(newCampground) });
 };
 
 module.exports.showCampground = async (req, res) => {
-    const { id } = req.params;
-    // //req.session.returnTo = req.originalUrl;
-    const campground = await Campground.findById(id).populate({
-        path: 'reviews',
-        populate: {
-            path: 'author'
-        }
-    }).populate('author');
-    req.accepts('html')
-        ? res.render('campground/show', { campground })
-        : res.status(200).json({ campground });
+  const { id } = req.params;
+  const campground = await Campground.findById(id)
+    .populate({
+      path: 'reviews',
+      populate: {
+        path: 'author'
+      }
+    })
+    .populate('author');
+
+  if (!campground) {
+    return res.status(404).json({ success: false, message: 'Campground not found' });
+  }
+
+  res.status(200).json({ success: true, campground: formatCampground(campground) });
 };
 
 module.exports.updateCampground = async (req, res) => {
-    const { id } = req.params;
-    // // console.log(req.body);
-    const campground = await Campground.findByIdAndUpdate(id, { ...req.body.campground }, { new: true, runValidators: true });
+  const { id } = req.params;
+  const campground = await Campground.findById(id);
 
-    //* we take only the data from the image array and store it in the database ; ...imgs (spread operator)
-    const imgs = (req.files || []).map(file => ({ url: file.path, filename: file.filename, originalname: file.originalname }))
-    //* we dont want to pass the image array as it is, we want to push the new images to the existing array
-    campground.image.push(...imgs);
+  if (!campground) {
+    return res.status(404).json({ success: false, message: 'Campground not found' });
+  }
 
-    // * below code is to delete the images from the database and cloudinary
-    const deleteImages = req.body.deleteImages;
-    if (deleteImages && deleteImages.length === campground.image.length) {
-        req.flash('error', 'You must have at least one image for the campground');
-        return res.redirect(`/campground/${campground._id}/edit`);
+  campground.set({ ...req.body.campground });
+
+  const newImages = (req.files || []).map((file) => ({
+    url: file.path,
+    filename: file.filename,
+    originalname: file.originalname
+  }));
+  campground.image.push(...newImages);
+
+  const deleteImagesRaw = req.body.deleteImages;
+  const deleteImages = Array.isArray(deleteImagesRaw)
+    ? deleteImagesRaw
+    : deleteImagesRaw
+    ? [deleteImagesRaw]
+    : [];
+
+  if (deleteImages.length && deleteImages.length >= campground.image.length && newImages.length === 0) {
+    return res
+      .status(400)
+      .json({ success: false, message: 'You must keep at least one image associated with the campground.' });
+  }
+
+  if (deleteImages.length) {
+    for (const filename of deleteImages) {
+      await cloudinary.uploader.destroy(filename);
     }
-    else if (deleteImages && deleteImages.length > 0) {
-        for (let filename of deleteImages) {
-            await cloudinary.uploader.destroy(filename);
-        }
-        await campground.updateOne({ $pull: { image: { filename: { $in: deleteImages } } } });
-    }
+    campground.image = campground.image.filter((image) => !deleteImages.includes(image.filename));
+  }
 
-    await campground.save();
-    req.flash('success', `Successfully updated <em><strong> ${campground.title} </strong></em>`);
-    res.redirect(`/campground/${campground._id}`);
-};
+  await campground.save();
+  const updatedCampground = await Campground.findById(id)
+    .populate('author')
+    .populate({
+      path: 'reviews',
+      populate: {
+        path: 'author'
+      }
+    });
 
-module.exports.showEditCampgroundForm = async (req, res) => {
-    const { id } = req.params;
-    const campground = await Campground.findById(id);
-    res.render('campground/edit', { campground });
+  res.status(200).json({ success: true, campground: formatCampground(updatedCampground) });
 };
 
 module.exports.deleteCampground = async (req, res) => {
-    const { id } = req.params;
-    const campground = await Campground.findById(id);
-    await Campground.findByIdAndDelete(id);
-    req.flash('error', `Successfully deleted <em><strong> ${campground.title} </strong></em>`)
-    res.redirect('/campground');
+  const { id } = req.params;
+  const campground = await Campground.findById(id);
+
+  if (!campground) {
+    return res.status(404).json({ success: false, message: 'Campground not found' });
+  }
+
+  const images = campground.image || [];
+  await Campground.findByIdAndDelete(id);
+
+  for (const image of images) {
+    if (image?.filename) {
+      await cloudinary.uploader.destroy(image.filename).catch(() => undefined);
+    }
+  }
+
+  res.status(200).json({ success: true, message: 'Campground deleted successfully' });
 };

--- a/controllers/review.js
+++ b/controllers/review.js
@@ -1,22 +1,55 @@
 const Campground = require('../model/campground');
 const Review = require('../model/review');
 
+const formatReview = (review) => {
+  if (!review) {
+    return null;
+  }
+  const doc = review.toObject ? review.toObject({ virtuals: true }) : review;
+  return {
+    _id: doc._id,
+    body: doc.body,
+    rating: doc.rating,
+    createdAt: doc.createdAt,
+    updatedAt: doc.updatedAt,
+    author: doc.author
+      ? {
+          _id: doc.author._id,
+          username: doc.author.username,
+          email: doc.author.email
+        }
+      : null
+  };
+};
+
 module.exports.addReview = async (req, res) => {
-    const { id } = req.params;
-    const campground = await Campground.findById(id);
-    const review = new Review(req.body.review);
-    review.author = req.user._id;
-    campground.reviews.push(review);
-    await review.save();
-    await campground.save();
-    req.flash('success', 'Created new review!');
-    res.redirect(`/campground/${campground._id}`);
+  const { id } = req.params;
+  const campground = await Campground.findById(id);
+
+  if (!campground) {
+    return res.status(404).json({ success: false, message: 'Campground not found' });
+  }
+
+  const review = new Review(req.body.review);
+  review.author = req.user._id;
+  campground.reviews.push(review);
+  await review.save();
+  await campground.save();
+  await review.populate('author');
+
+  res.status(201).json({ success: true, review: formatReview(review) });
 };
 
 module.exports.deleteReview = async (req, res) => {
-    const { id, reviewId } = req.params;
-    await Campground.findByIdAndUpdate(id, { $pull: { reviews: reviewId } });
-    await Review.findByIdAndDelete(reviewId);
-    req.flash('error', 'Successfully deleted review!');
-    res.redirect(`/campground/${id}`);
+  const { id, reviewId } = req.params;
+  const review = await Review.findById(reviewId);
+
+  if (!review) {
+    return res.status(404).json({ success: false, message: 'Review not found' });
+  }
+
+  await Campground.findByIdAndUpdate(id, { $pull: { reviews: reviewId } });
+  await Review.findByIdAndDelete(reviewId);
+
+  res.status(200).json({ success: true, message: 'Review deleted successfully' });
 };

--- a/middleware/middleware.js
+++ b/middleware/middleware.js
@@ -4,103 +4,68 @@ const mongoose = require('mongoose');
 const Campground = require('../model/campground');
 const Review = require('../model/review');
 
-// ? Middleware for Log in CampVenture
 module.exports.isLoggedIn = (req, res, next) => {
-    if (!req.isAuthenticated()) {
-        req.session.returnTo = req.originalUrl; // add this line
-        req.flash('error', 'You must be signed in first!');
-        if (req.accepts('html')) {
-            return res.redirect('/login');
-        } else {
-            return res.status(401).json({ error: 'You must be signed in first!' });
-        }
-    }
-    next();
-}
+  if (!req.isAuthenticated || !req.isAuthenticated()) {
+    return res.status(401).json({ success: false, message: 'You must be signed in first!' });
+  }
+  next();
+};
 
-// ? Middleware to validate the campground
 module.exports.validateCampground = (req, res, next) => {
-    const { error } = campgroundSchema.validate(req.body);
-    if (error) {
-        const msg = error.details.map(el => el.message).join(',');
-        if (req.accepts('html')) {
-            return next(new ExpressError(msg, 400))
-        } else {
-            return res.status(400).json({ error: msg });
-        }
-    }
-    else {
-        next();
-    }
-}
+  const { error } = campgroundSchema.validate(req.body);
+  if (error) {
+    const message = error.details.map((el) => el.message).join(',');
+    return next(new ExpressError(message, 400));
+  }
+  next();
+};
 
-// ? Middleware to validate the review
 module.exports.validateReview = (req, res, next) => {
-    const { error } = reviewSchema.validate(req.body);
-    if (error) {
-        const msg = error.details.map(el => el.message).join(',');
-        throw new ExpressError(msg, 400);
-    }
-    else {
-        next();
-    }
-}
+  const { error } = reviewSchema.validate(req.body);
+  if (error) {
+    const message = error.details.map((el) => el.message).join(',');
+    return next(new ExpressError(message, 400));
+  }
+  next();
+};
 
-// ? Middleware to store the returnTo value in res.locals
-module.exports.storeReturnTo = (req, res, next) => {
-    if (req.session.returnTo) {
-        res.locals.returnTo = req.session.returnTo;
-    }
-    next();
-}
-
-// ? Middleware to validate the campground id
 module.exports.validateCampgroundId = (req, res, next) => {
-    const { id } = req.params;
-    if (!mongoose.Types.ObjectId.isValid(id)) {
-        req.flash('error', `Invalid Id: No campgrounds were found!`);
-        if (req.accepts('html')) {
-            return res.redirect('/campground');
-        } else {
-            return res.status(404).json({ error: `Invalid Id: No campgrounds were found!` });
-        }
-    };
-    next();
-}
+  const { id } = req.params;
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    return next(new ExpressError('Invalid campground id provided', 404));
+  }
+  next();
+};
 
-// ? Middleware to check if the user is the author of the campground
-module.exports.isAuthor = async (req, res, next) => {
-    const { id } = req.params;
-    const campground = await Campground.findById(id);
-    if (!req.user || !campground.author.equals(req.user._id)) {
-        req.flash('error', 'You do not have permission to do that!');
-        return res.redirect(`/campground/${id}`);
-    };
-    next();
-}
-
-// ? Middleware to check if the user is the author of the review campground
-module.exports.isReviewAuthor = async (req, res, next) => {
-    const { id, reviewId } = req.params;
-    const review = await Review.findById(reviewId);
-    if (!req.user || !review.author.equals(req.user._id)) {
-        req.flash('error', 'You do not have permission to do that!');
-        return res.redirect(`/campground/${id}`);
-    };
-    next();
-}
-
-// ? Middleware to check if the campground exists
 module.exports.isCampgroundExist = async (req, res, next) => {
-    const { id } = req.params;
-    const campground = await Campground.findById(id);
-    if (!campground) {
-        req.flash('error', 'No campgrounds were found!');
-        if (req.accepts('html')) {
-            return res.redirect('/campground');
-        } else {
-            return res.status(404).json({ error: 'No campgrounds were found!' });
-        }
-    };
-    next();
-}
+  const { id } = req.params;
+  const campground = await Campground.findById(id);
+  if (!campground) {
+    return next(new ExpressError('Campground not found', 404));
+  }
+  res.locals.campground = campground;
+  next();
+};
+
+module.exports.isAuthor = async (req, res, next) => {
+  const campground = res.locals.campground || (await Campground.findById(req.params.id));
+  if (!campground) {
+    return next(new ExpressError('Campground not found', 404));
+  }
+  if (!req.user || !campground.author.equals(req.user._id)) {
+    return res.status(403).json({ success: false, message: 'You do not have permission to modify this campground.' });
+  }
+  next();
+};
+
+module.exports.isReviewAuthor = async (req, res, next) => {
+  const { reviewId } = req.params;
+  const review = await Review.findById(reviewId);
+  if (!review) {
+    return next(new ExpressError('Review not found', 404));
+  }
+  if (!req.user || !review.author.equals(req.user._id)) {
+    return res.status(403).json({ success: false, message: 'You do not have permission to modify this review.' });
+  }
+  next();
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "start": "node app.js",
     "dev": "cross-env NODE_ENV=DEVELOPMENT nodemon app.js",
-    "prod": "cross-env NODE_ENV=PRODUCTION node app.js"
+    "prod": "cross-env NODE_ENV=PRODUCTION node app.js",
+    "client:install": "npm install --prefix client",
+    "client:dev": "npm run dev --prefix client",
+    "client:build": "npm run build --prefix client",
+    "client:test": "npm run test --prefix client"
   },
   "author": "Aiman Naim",
   "license": "ISC",

--- a/routes/campground.js
+++ b/routes/campground.js
@@ -1,55 +1,35 @@
 const express = require('express');
 const router = express.Router();
 const catchAsync = require('../utils/catchAsync');
-const { validateCampground, isLoggedIn, validateCampgroundId, isAuthor, isCampgroundExist } = require('../middleware/middleware');
+const {
+  validateCampground,
+  isLoggedIn,
+  validateCampgroundId,
+  isAuthor,
+  isCampgroundExist
+} = require('../middleware/middleware');
 const campground = require('../controllers/campground');
 const multer = require('multer');
 const { storage } = require('../cloudinary/cloudinary');
-const upload = multer({ storage })
+const upload = multer({ storage });
 
-router.route('/')
-    .get(catchAsync(campground.index))
-    .post(
-        isLoggedIn,
-        upload.array('image', 10),
-        validateCampground,
-        catchAsync(campground.newCampground)
-    );
+router
+  .route('/')
+  .get(catchAsync(campground.index))
+  .post(isLoggedIn, upload.array('image', 10), validateCampground, catchAsync(campground.newCampground));
 
-router.get('/new',
-    isLoggedIn,
-    campground.renderNewCampgroundForm
-);
-
-router.route('/:id')
-    .get(
-        validateCampgroundId,
-        isCampgroundExist,
-        catchAsync(campground.showCampground)
-    )
-    .put(
-        validateCampgroundId,
-        isCampgroundExist,
-        isLoggedIn,
-        isAuthor,
-        upload.array('image', 10),
-        validateCampground,
-        catchAsync(campground.updateCampground)
-    )
-    .delete(
-        validateCampgroundId,
-        isCampgroundExist,
-        isLoggedIn,
-        isAuthor,
-        catchAsync(campground.deleteCampground)
-    );
-
-router.get('/:id/edit',
-    isLoggedIn,
+router
+  .route('/:id')
+  .get(validateCampgroundId, isCampgroundExist, catchAsync(campground.showCampground))
+  .put(
     validateCampgroundId,
     isCampgroundExist,
+    isLoggedIn,
     isAuthor,
-    catchAsync(campground.showEditCampgroundForm)
-);
+    upload.array('image', 10),
+    validateCampground,
+    catchAsync(campground.updateCampground)
+  )
+  .delete(validateCampgroundId, isCampgroundExist, isLoggedIn, isAuthor, catchAsync(campground.deleteCampground));
 
 module.exports = router;

--- a/routes/review.js
+++ b/routes/review.js
@@ -1,24 +1,31 @@
 const express = require('express');
-// mergeParams: true is used to merge the params from the parent router
 const router = express.Router({ mergeParams: true });
 const catchAsync = require('../utils/catchAsync');
-const { validateReview, isLoggedIn, isReviewAuthor } = require('../middleware/middleware');
+const {
+  validateReview,
+  isLoggedIn,
+  isReviewAuthor,
+  validateCampgroundId,
+  isCampgroundExist
+} = require('../middleware/middleware');
 const review = require('../controllers/review');
-const campground = require('../controllers/campground');
 
-router.get('/',
-    catchAsync(campground.showCampground)
+router.post(
+  '/',
+  validateCampgroundId,
+  isCampgroundExist,
+  isLoggedIn,
+  validateReview,
+  catchAsync(review.addReview)
 );
 
-router.post('/',
-    isLoggedIn,
-    validateReview,
-    catchAsync(review.addReview)
-);
-
-router.delete('/:reviewId',
-    isReviewAuthor,
-    catchAsync(review.deleteReview)
+router.delete(
+  '/:reviewId',
+  validateCampgroundId,
+  isCampgroundExist,
+  isLoggedIn,
+  isReviewAuthor,
+  catchAsync(review.deleteReview)
 );
 
 module.exports = router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,26 +1,11 @@
 const express = require('express');
 const router = express.Router();
 const catchAsync = require('../utils/catchAsync');
-const passport = require('passport');
-const { storeReturnTo } = require('../middleware/middleware');
-
 const user = require('../controllers/user');
 
-router.route('/register')
-    .get(user.renderRegisterPage)
-    .post(catchAsync(user.registerUser));
-
-router.route('/login')
-    .get(user.renderLoginPage)
-    .post(
-        // use the storeReturnTo middleware to save the returnTo value from session to res.locals
-        storeReturnTo,
-        // passport.authenticate logs the user in and clears req.session
-        passport.authenticate('local', { failureFlash: true, failureRedirect: '/login' }),
-        // Now we can use res.locals.returnTo to redirect the user after login
-        user.loginUser
-    );
-
+router.post('/register', catchAsync(user.registerUser));
+router.post('/login', user.loginUser);
 router.post('/logout', user.logoutUser);
+router.get('/me', user.currentUser);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- scaffolded a Vite-powered React client with routed pages, authentication context, campground views, and Mapbox maps
- refactored the Express server to serve the SPA build, expose JSON REST endpoints, and harden session/CORS handling for the client
- updated campground, review, and user controllers plus middleware to return structured JSON payloads and sanitised data; refreshed docs and scripts for the new workflow
- replaced bundled client imagery with lightweight emoji and remote placeholders, documenting how to add custom branding assets

## Testing
- not run (node module installation unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e8a49940ac832c96fa3fe97dd71bc2